### PR TITLE
Implement set secret command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "base64"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+
+[[package]]
 name = "bit-set"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +356,7 @@ name = "dadmin"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.12.1",
  "color-backtrace",
  "dialoguer",
  "dirs 2.0.2",
@@ -363,6 +370,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
+ "sodiumoxide",
  "structopt",
  "tempfile",
  "thiserror",
@@ -486,6 +494,18 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "filetime"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "findshlibs"
@@ -904,6 +924,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
 
 [[package]]
+name = "libflate"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "rle-decode-fast",
+ "take_mut",
+]
+
+[[package]]
 name = "libgit2-sys"
 version = "0.12.5+1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +947,20 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libsodium-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c344ff12b90ef8fa1f0fffacd348c1fd041db331841fec9eab23fdb991f5e73"
+dependencies = [
+ "cc",
+ "libc",
+ "libflate",
+ "pkg-config",
+ "tar",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1495,7 +1541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.11.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1526,12 +1572,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+
+[[package]]
 name = "rust-argon2"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -1669,6 +1721,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
+name = "sodiumoxide"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585232e78a4fc18133eef9946d3080befdf68b906c51b621531c37e91787fa2b"
+dependencies = [
+ "libc",
+ "libsodium-sys",
+ "serde",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,6 +1810,24 @@ dependencies = [
  "quote 1.0.3",
  "syn 1.0.16",
  "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tar"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
+dependencies = [
+ "filetime",
+ "libc",
+ "redox_syscall",
+ "xattr",
 ]
 
 [[package]]
@@ -2161,4 +2242,13 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4.8"
 color-backtrace = "0.3.0"
 pretty_env_logger = "0.4.0"
 prettytable-rs = "0.8.0"
+
 reqwest = { version = "0.10.3", features = ["blocking", "json", "gzip"] }
 graphql_client = "0.8.0"
 
@@ -27,6 +28,9 @@ regex = "1.3.4"
 git2 = "0.13.5"
 git2_credentials = "0.6.0"
 dialoguer = "0.5.0"
+
+sodiumoxide = "0.2.5"
+base64 = "0.12.1"
 
 [dev-dependencies]
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -181,7 +181,7 @@ OPTIONS:
 
 ```
 dadmin-set-secret 0.1.0
-Set description and/or website for all repositories that match regex
+Set a secret all repositories that match regex
 
 USAGE:
     dadmin set secret [OPTIONS] --name <name> --regex <regex> --value <value>

--- a/USAGE.md
+++ b/USAGE.md
@@ -177,6 +177,26 @@ OPTIONS:
     -w, --website <website>              Hompage, this is required unless description is provided
 ```
 
+## Set secret
+
+```
+dadmin-set-secret 0.1.0
+Set description and/or website for all repositories that match regex
+
+USAGE:
+    dadmin set secret [OPTIONS] --name <name> --regex <regex> --value <value>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -n, --name <name>                    The name of your secret
+    -o, --organisation <organisation>    Target organisation name [default: divvun]
+    -r, --regex <regex>                  Optional regex to filter repositories
+    -v, --value <value>                  The value for your secret
+```
+
 ## Topic
 
 ```

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod set_secret;
 pub mod add_users;
 pub mod apply;
 pub mod branch;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,4 @@
 pub mod add;
-pub mod set_secret;
 pub mod add_users;
 pub mod apply;
 pub mod branch;
@@ -28,6 +27,7 @@ pub mod remove_repos;
 pub mod remove_users;
 pub mod set;
 pub mod set_info;
+pub mod set_secret;
 pub mod set_team_permission;
 pub mod show;
 pub mod show_config;

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -1,4 +1,5 @@
 use super::set_info::*;
+use super::set_secret::*;
 use super::set_team_permission::*;
 use anyhow::Result;
 use structopt::StructOpt;
@@ -9,6 +10,8 @@ pub enum SetArgs {
     Info(InfoArgs),
     #[structopt(name = "permission")]
     Permission(SetTeamPermissionArgs),
+    #[structopt(name = "secret")]
+    Secret(SecretArgs),
 }
 
 impl SetArgs {
@@ -16,6 +19,7 @@ impl SetArgs {
         match self {
             SetArgs::Permission(args) => args.set_permission(),
             SetArgs::Info(args) => args.run(),
+            SetArgs::Secret(args) => args.run(),
         }
     }
 }

--- a/src/commands/set_secret.rs
+++ b/src/commands/set_secret.rs
@@ -8,7 +8,7 @@ use sodiumoxide::crypto::sealedbox;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-/// Set description and/or website for all repositories that match regex
+/// Set a secret all repositories that match regex
 pub struct SecretArgs {
     #[structopt(long, short, default_value = "divvun")]
     /// Target organisation name

--- a/src/commands/set_secret.rs
+++ b/src/commands/set_secret.rs
@@ -1,0 +1,67 @@
+use super::common;
+use crate::github;
+use crate::github::RemoteRepo;
+use anyhow::{Context, Result};
+use sodiumoxide::crypto::sealedbox;
+use sodiumoxide::crypto::box_::curve25519xsalsa20poly1305::PublicKey;
+use crate::filter::Filter;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+/// Set description and/or website for all repositories that match regex
+pub struct SecretArgs {
+    #[structopt(long, short, default_value = "divvun")]
+    /// Target organisation name
+    pub organisation: String,
+    #[structopt(long, short)]
+    /// Optional regex to filter repositories
+    pub regex: Filter,
+    #[structopt(long, short, required_unless("website"))]
+    /// The value for your secret
+    pub value: String,
+    #[structopt(long, short, required_unless("description"))]
+    /// The name of your secret
+    pub name: String,
+}
+
+impl SecretArgs {
+    pub fn run(&self) -> Result<()> {
+        let user_token = common::user_token()?;
+
+        let filtered_repos = common::query_and_filter_repositories(
+            &self.organisation,
+            Some(&self.regex),
+            &user_token,
+        )?;
+
+        for repo in filtered_repos {
+            let result = set_secret(
+                &repo,
+                &self.value,
+                &self.name,
+                &user_token,
+            );
+            match result {
+                Ok(_) => println!("Set secret value for repo {} successfully", repo.name),
+                Err(e) => println!("Failed to set secret value for repo {} because {:?}", repo.name, e),
+            }
+        }
+        Ok(())
+    }
+}
+
+fn set_secret(repo: &RemoteRepo, value: &str, name: &str, token: &str) -> Result<()> {
+    let public_key = github::get_public_key(repo, token)?;
+    let encrypted_value = encrypt(value, &public_key.key)?;
+    github::set_secret(repo, name, &encrypted_value, &public_key.key_id, token)?;
+    Ok(())
+}
+
+fn encrypt(value: &str, key: &str) -> Result<String> {
+    let bytes = base64::decode(key)?;
+    let public_key = PublicKey::from_slice(&bytes)
+                .context("Invalid public key from github")?;
+    let encrypted = sealedbox::seal(value.as_bytes(), &public_key);
+    let encrypted = base64::encode(encrypted);
+    Ok(encrypted)
+}

--- a/src/commands/template/apply.rs
+++ b/src/commands/template/apply.rs
@@ -238,10 +238,9 @@ fn previous_template_sha(template_repo: &Repository, target_delta: &TargetDelta)
         let rev = rev?;
         let commit = template_repo.find_commit(rev.clone())?;
         let tree = commit.tree()?;
-        let entry = tree.get_path(Path::new(".gut/template.toml"));
 
-        if entry.is_ok() {
-            let object = entry.unwrap().to_object(&template_repo)?;
+        if let Ok(entry) = tree.get_path(Path::new(".gut/template.toml")) {
+            let object = entry.to_object(&template_repo)?;
             let blob = object.peel_to_blob()?;
             let content = str::from_utf8(blob.content())?;
             if let Ok(delta) = toml::from_str::<TemplateDelta>(content) {

--- a/src/github/rest.rs
+++ b/src/github/rest.rs
@@ -544,11 +544,7 @@ pub fn get_public_key(repo: &RemoteRepo, token: &str) -> Result<PublicKey> {
         repo.owner, repo.name
     );
 
-    let response = get(
-        &url,
-        token,
-        None
-    )?;
+    let response = get(&url, token, None)?;
 
     let status = response.status();
 
@@ -570,7 +566,13 @@ pub struct PublicKey {
     pub key: String,
 }
 
-pub fn set_secret(repo: &RemoteRepo, name: &str, encrypted_value: &str, key_id: &str, token: &str) -> Result<()> {
+pub fn set_secret(
+    repo: &RemoteRepo,
+    name: &str,
+    encrypted_value: &str,
+    key_id: &str,
+    token: &str,
+) -> Result<()> {
     let url = format!(
         "https://api.github.com/repos/{}/{}/actions/secrets/{}",
         repo.owner, repo.name, name


### PR DESCRIPTION
```
dadmin-set-secret 0.1.0
Set a secret all repositories that match regex
USAGE:
    dadmin set secret [OPTIONS] --name <name> --regex <regex> --value <value>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -n, --name <name>                    The name of your secret
    -o, --organisation <organisation>    Target organisation name [default: divvun]
    -r, --regex <regex>                  Optional regex to filter repositories
    -v, --value <value>                  The value for your secret
```