### PR TITLE
Rename tool to gut

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -1,4 +1,4 @@
-name: Dadmin Check
+name: Gut Check
 
 on:
   push:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "gut"
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,33 +352,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dadmin"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "base64 0.12.1",
- "color-backtrace",
- "dialoguer",
- "dirs 2.0.2",
- "git2",
- "git2_credentials",
- "graphql_client",
- "log",
- "pretty_env_logger",
- "prettytable-rs",
- "proptest",
- "regex",
- "reqwest",
- "serde",
- "sodiumoxide",
- "structopt",
- "tempfile",
- "thiserror",
- "toml",
- "uuid",
-]
-
-[[package]]
 name = "dialoguer"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +704,33 @@ dependencies = [
  "graphql_client_codegen",
  "proc-macro2 0.4.30",
  "syn 0.15.44",
+]
+
+[[package]]
+name = "gut"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.12.1",
+ "color-backtrace",
+ "dialoguer",
+ "dirs 2.0.2",
+ "git2",
+ "git2_credentials",
+ "graphql_client",
+ "log",
+ "pretty_env_logger",
+ "prettytable-rs",
+ "proptest",
+ "regex",
+ "reqwest",
+ "serde",
+ "sodiumoxide",
+ "structopt",
+ "tempfile",
+ "thiserror",
+ "toml",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "color-backtrace"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d13f1078cc63c791d0deba0dd43db37c9ec02b311f10bed10b577016f3a957"
+checksum = "2e427db71d57c700854e986f904c84032e3b2d850c3059840e50e82cbadae37e"
 dependencies = [
  "atty",
  "backtrace",
@@ -442,9 +442,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.20",
+ "proc-macro2",
+ "quote",
+ "syn",
  "synstructure",
 ]
 
@@ -610,6 +610,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-introspection-query"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610aac641dbd2a457ad4cef34aa2827dae3f035fd214cb38c2d62d8543f3973f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "graphql-parser"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,12 +630,11 @@ dependencies = [
 
 [[package]]
 name = "graphql_client"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384bd6253c9c37eac529ba6ff6eae31ed99a3532664cf7b7f48f240f77f73699"
+checksum = "a0bb4f09181e4f80018d01c612125b07e0156f3753bfac37055fe2a25e031ca8"
 dependencies = [
  "doc-comment",
- "failure",
  "graphql_query_derive",
  "serde",
  "serde_json",
@@ -634,31 +642,32 @@ dependencies = [
 
 [[package]]
 name = "graphql_client_codegen"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbbd911d25d37c6113fecbde95619869117a1903dad9dc0b94bbf1ac4c3d2747"
+checksum = "8e304c223c809b3bff4614018f8e6d9edb176b31d64ed9ea48b6ae8b1a03abb9"
 dependencies = [
  "failure",
+ "graphql-introspection-query",
  "graphql-parser",
  "heck",
  "lazy_static",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
+ "proc-macro2",
+ "quote",
  "serde",
  "serde_json",
- "syn 0.15.44",
+ "syn",
 ]
 
 [[package]]
 name = "graphql_query_derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d251ffd6428a2a6a0fde38539a3858816fa2aa70bcfcc0a16968c93d51d0c7"
+checksum = "e1f6b14d5ce549227aa9e649cd9d36d008b91021275a8e0a67d71cef815adc2f"
 dependencies = [
  "failure",
  "graphql_client_codegen",
- "proc-macro2 0.4.30",
- "syn 0.15.44",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1130,9 +1139,9 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82996f11efccb19b685b14b5df818de31c1edcee3daa256ab5775dd98e72feb"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.20",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1190,9 +1199,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.20",
+ "proc-macro2",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -1202,20 +1211,11 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.20",
+ "proc-macro2",
+ "quote",
+ "syn",
  "syn-mid",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -1224,7 +1224,7 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
- "unicode-xid 0.2.0",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1255,20 +1255,11 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
- "proc-macro2 1.0.12",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1607,9 +1598,9 @@ version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.20",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1683,20 +1674,9 @@ checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.20",
-]
-
-[[package]]
-name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1705,9 +1685,9 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd1b5e337360b1fae433c59fcafa0c6b77c605e92540afa5221a7b81a9eca91d"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "unicode-xid 0.2.0",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1716,9 +1696,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.20",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1727,10 +1707,10 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.20",
- "unicode-xid 0.2.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1828,9 +1808,9 @@ version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.20",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1956,12 +1936,6 @@ checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
@@ -2066,9 +2040,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.20",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2090,7 +2064,7 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.4",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2100,9 +2074,9 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.20",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,14 +2,11 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4e698660ed2d0f625c39bb877332b4269668720e330e2aa3d67bb1187a656a"
+checksum = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
 dependencies = [
- "fallible-iterator",
  "gimli",
- "lazycell",
- "smallvec",
 ]
 
 [[package]]
@@ -38,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "013a6e0a2cbe3d20f9c60b65458f7a7f7a5e636c5d0f45a5a6aee5d4b1f01785"
+checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 
 [[package]]
 name = "arrayref"
@@ -62,9 +59,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "async-compression"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d37ca0ddff0c8afe8307cd4cc3636c19f0fa09ecfc642344b1597d08a19d1a2"
+checksum = "2d548918a155e5d6f19f414450e184a632ba492bd09f0e8e4622919ccb940664"
 dependencies = [
  "bytes",
  "flate2",
@@ -98,28 +95,15 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad235dabf00f36301792cfe82499880ba54c6486be094d1047b02bacb67c14e8"
+checksum = "a5393cb2f40a6fae0014c9af00018e95846f3b241b331a6b7733c326d3e58108"
 dependencies = [
  "addr2line",
- "backtrace-sys",
  "cfg-if",
- "findshlibs",
- "goblin",
  "libc",
- "memmap",
+ "object",
  "rustc-demangle",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca797db0057bae1a7aa2eef3283a874695455cecf08a43bfb8507ee0ebc1ed69"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -136,18 +120,18 @@ checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
 
 [[package]]
 name = "bit-set"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
+checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
 
 [[package]]
 name = "bitflags"
@@ -168,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
+checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -180,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
+checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
 
 [[package]]
 name = "byteorder"
@@ -198,9 +182,9 @@ checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
 dependencies = [
  "jobserver",
 ]
@@ -213,9 +197,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
  "ansi_term",
  "atty",
@@ -273,15 +257,16 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6728a28023f207181b193262711102bfbaf47cc9d13bc71d0736607ef8efe88c"
+checksum = "2586208b33573b7f76ccfbe5adb076394c88deaf81b84d7213969805b0a952a7"
 dependencies = [
  "clicolors-control",
  "encode_unicode",
  "lazy_static",
  "libc",
  "regex",
+ "terminal_size",
  "termios",
  "unicode-width",
  "winapi 0.3.8",
@@ -353,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94616e25d2c04fc97253d145f6ca33ad84a584258dc70c4e621cc79a57f903b6"
+checksum = "d8b5eb0fce3c4f955b8d8d864b131fb8863959138da962026c106ba7a2e3bf7a"
 dependencies = [
  "console",
  "lazy_static",
@@ -397,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "doc-comment"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807e5847c39ad6a11eac66de492ed1406f76a260eb8656e8740cad9eabc69c27"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
@@ -443,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -453,21 +438,15 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.20",
  "synstructure",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "filetime"
@@ -482,20 +461,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "findshlibs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1260d61e4fe2a6ab845ffdc426a0bd68ffb240b91cf0ec5a8d1170cec535bd8"
-dependencies = [
- "lazy_static",
- "libc",
-]
-
-[[package]]
 name = "flate2"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
+checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -548,47 +517,51 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
 name = "futures-io"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
 
 [[package]]
 name = "futures-task"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
  "futures-core",
  "futures-io",
  "futures-task",
  "memchr",
+ "pin-project",
  "pin-utils",
  "slab",
 ]
@@ -606,16 +579,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dd6190aad0f05ddbbf3245c54ed14ca4aa6dd32f22312b70d8f168c3e3e633"
-dependencies = [
- "arrayvec",
- "byteorder",
- "fallible-iterator",
- "smallvec",
- "stable_deref_trait",
-]
+checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "git2"
@@ -641,17 +607,6 @@ dependencies = [
  "dialoguer",
  "dirs 2.0.2",
  "git2",
-]
-
-[[package]]
-name = "goblin"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd5e3132801a1ac34ac53b97acde50c4685414dd2f291b9ea52afa6f07468c8"
-dependencies = [
- "log",
- "plain",
- "scroll",
 ]
 
 [[package]]
@@ -735,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5c295d1c0c68e4e42003d75f908f5e16a1edd1cbe0b0d02e4dc2006a384f47"
+checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
 dependencies = [
  "bytes",
  "fnv",
@@ -763,18 +718,18 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.8"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
  "bytes",
  "fnv",
@@ -808,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b15203263d1faa615f9337d79c1d37959439dc46c2b4faab33286fadc2a1c5"
+checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -889,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.36"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
+checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -913,16 +868,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
-
-[[package]]
 name = "libc"
-version = "0.2.67"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
+checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
 
 [[package]]
 name = "libflate"
@@ -966,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb70f29dc7c31d32c97577f13f41221af981b31248083e347b7f2c39225a6bc"
+checksum = "d45f516b9b19ea6c940b9f36d36734062a153a2b4cc9ef31d82c54bb9780f525"
 dependencies = [
  "cc",
  "libc",
@@ -1012,16 +961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
  "cfg-if",
  "fuchsia-zircon",
@@ -1097,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1117,19 +1056,31 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.28"
+name = "object"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
+checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+
+[[package]]
+name = "once_cell"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
+
+[[package]]
+name = "openssl"
+version = "0.10.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1147,9 +1098,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.54"
+version = "0.9.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
+checksum = "f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e"
 dependencies = [
  "autocfg 1.0.0",
  "cc",
@@ -1166,47 +1117,41 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.8"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
+checksum = "81d480cb4e89522ccda96d0eed9af94180b7a5f93fb28f66e1fd7d68431663d1"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.8"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
+checksum = "a82996f11efccb19b685b14b5df818de31c1edcee3daa256ab5775dd98e72feb"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.20",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+checksum = "f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f"
 
 [[package]]
 name = "pin-utils"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "ppv-lite86"
@@ -1240,26 +1185,26 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7959c6467d962050d639361f7703b2051c43036d03493c36f01d440fdd3138a"
+checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.20",
  "version_check",
 ]
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "0.4.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4002d9f55991d5e019fb940a90e1a95eb80c24e77cb2462dd4dc869604d543a"
+checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.20",
  "syn-mid",
  "version_check",
 ]
@@ -1275,18 +1220,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
+checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
 
 [[package]]
 name = "proptest"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6147d103a7c9d7598f4105cf049b15c99e2ecd93179bf024f0fd349be5ada4"
+checksum = "01c477819b845fe023d33583ebf10c9f62518c8d79a0960ba5c36d6ac8a55a5b"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -1319,11 +1264,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.12",
 ]
 
 [[package]]
@@ -1501,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.5"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8900ebc1363efa7ea1c399ccc32daed870b4002651e0bed86e72d501ebbe0048"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1610,57 +1555,38 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "schannel"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi 0.3.8",
 ]
 
 [[package]]
-name = "scroll"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
-dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
-]
-
-[[package]]
 name = "security-framework"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97bbedbe81904398b6ebb054b3e912f99d55807125790f3198ac990d98def5b0"
+checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
+ "libc",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fd2f23e31ef68dd2328cc383bd493142e46107a3a0e24f7d734e3f3b80fe4c"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1668,29 +1594,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.104"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.20",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.48"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
+checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 dependencies = [
  "itoa",
  "ryu",
@@ -1717,9 +1643,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "sodiumoxide"
@@ -1733,12 +1659,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,9 +1666,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe43617218c0805c6eb37160119dc3c548110a67786da7218d1c6555212f073"
+checksum = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1757,15 +1677,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e79c80e0f4efd86ca960218d4e056249be189ff1c42824dcd9a7f51a56f0bd"
+checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.20",
 ]
 
 [[package]]
@@ -1781,12 +1701,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.16"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
+checksum = "dd1b5e337360b1fae433c59fcafa0c6b77c605e92540afa5221a7b81a9eca91d"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
  "unicode-xid 0.2.0",
 ]
 
@@ -1796,9 +1716,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.20",
 ]
 
 [[package]]
@@ -1807,9 +1727,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.20",
  "unicode-xid 0.2.0",
 ]
 
@@ -1866,10 +1786,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "termios"
-version = "0.3.1"
+name = "terminal_size"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
+checksum = "8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0fcee7b24a25675de40d5bb4de6e41b0df07bc9856295e7e2b3a3600c400c2"
 dependencies = [
  "libc",
 ]
@@ -1885,22 +1815,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.11"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee14bf8e6767ab4c687c9e8bc003879e042a96fd67a3ba5934eadb6536bef4db"
+checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.11"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
+checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.20",
 ]
 
 [[package]]
@@ -1914,23 +1844,23 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "redox_syscall",
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "tokio"
-version = "0.2.13"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa5e81d6bc4e67fe889d5783bd2a128ab2e0cfa487e0be16b6a8d177b101616"
+checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
 dependencies = [
  "bytes",
  "fnv",
+ "futures-core",
  "iovec",
  "lazy_static",
  "memchr",
@@ -1942,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
  "tokio",
@@ -1952,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2074,9 +2004,9 @@ checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -2117,9 +2047,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.59"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
+checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
  "cfg-if",
  "serde",
@@ -2129,24 +2059,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.59"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0da9c9a19850d3af6df1cb9574970b566d617ecfaf36eb0b706b6f3ef9bd2f8"
+checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.20",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457414a91863c0ec00090dba537f88ab955d93ca6555862c29b6d860990b8a8a"
+checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2156,38 +2086,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.59"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6fde1d36e75a714b5fe0cffbb78978f222ea6baebb726af13c78869fdb4205"
+checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.59"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bda4168030a6412ea8a047e27238cadf56f0e53516e1e83fec0a8b7c786f6d"
+checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.20",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.59"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9f36ad51f25b0219a3d4d13b90eb44cd075dff8b6280cca015775d7acaddd8"
+checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
 
 [[package]]
 name = "web-sys"
-version = "0.3.36"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721c6263e2c66fd44501cc5efbfa2b7dfa775d13e4ea38c46299646ed1f9c70a"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2223,9 +2153,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi 0.3.8",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "dadmin"
+name = "gut"
 version = "0.1.0"
-authors = ["Hampus Forsvall <hampusf@technocreatives.com>"]
+authors = ["Hampus Forsvall <hampusf@technocreatives.com>", "Thanh Le <thanh@technocreatives.com>"]
 edition = "2018"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Hampus Forsvall <hampusf@technocreatives.com>", "Thanh Le <thanh@tec
 edition = "2018"
 
 [dependencies]
-
 toml = "0.5.6"
 serde = { version = "1.0", features = ["derive"] }
 
@@ -15,12 +14,12 @@ thiserror = "1.0.11"
 anyhow = "1.0.26"
 
 log = "0.4.8"
-color-backtrace = "0.3.0"
+color-backtrace = "0.4.0"
 pretty_env_logger = "0.4.0"
 prettytable-rs = "0.8.0"
 
 reqwest = { version = "0.10.3", features = ["blocking", "json", "gzip"] }
-graphql_client = "0.8.0"
+graphql_client = "0.9.0"
 
 dirs = "2.0"
 regex = "1.3.4"
@@ -34,6 +33,5 @@ base64 = "0.12.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
-
 proptest = "0.9.5"
 tempfile = "3.1.0"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# project-dadmin
+# gut
 
-![](https://github.com/divvun/project-dadmin/workflows/Dadmin%20Check/badge.svg)
+![](https://github.com/divvun/gut/workflows/Gut%20Check/badge.svg)
 
 This is a Git(Hub) multirepo maintenance tool, designed specific for divvun.
+We think it's pretty good.
 
 There are some [usage instructions](USAGE.md) under development.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -3,13 +3,13 @@
 ## Add Users
 
 ```
-dadmin-add-users 0.1.0
+gut-add-users 0.1.0
 Invite users to an organisation by usernames.
 
 If you specify team_slug it'll try to invite users to the provided team
 
 USAGE:
-    dadmin add users [OPTIONS]
+    gut add users [OPTIONS]
 
 FLAGS:
     -h, --help
@@ -46,11 +46,11 @@ Sends an invitation request to the specified user(s), to become a member of the 
 ## Invite Users
 
 ```
-dadmin-invite-users 0.1.0
+gut-invite-users 0.1.0
 Invite users to an organisation by emails
 
 USAGE:
-    dadmin invite users [OPTIONS]
+    gut invite users [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information
@@ -69,23 +69,23 @@ Invite users by emails.
 
 ## Merge
 
-`dadmin merge -o <org> -r <regex> --branch <branch> --abort-if-conflict`
+`gut merge -o <org> -r <regex> --branch <branch> --abort-if-conflict`
 
 ### Effect
 
 This command will try to merge a branch into your head branch for all repositories that match a regex pattern.
 
-This works similar to `git merge` command. Dadmin will use `fast-forward` strategy whenever possible.
+This works similar to `git merge` command. gut will use `fast-forward` strategy whenever possible.
 
 If there is a conflict, that it cannot resolve automatically, you'll need to fix all conflicts and then commit it yourself. Or you can use `--abort-if-conflict` option to abort it.
 
-Dadmin also shows all merge conflict files as normal `git merge` command.
+gut also shows all merge conflict files as normal `git merge` command.
 
 If you want to merge a branch `A` into branch `B`, you can check out branch `B` first and then use this merge command.
 
 ## Clean
 
-`dadmin clean -o <org> -r <regex>`
+`gut clean -o <org> -r <regex>`
 
 ### Effect
 
@@ -93,7 +93,7 @@ This command will try to simulate `git clean -f -d` command. It will clean all l
 
 ## Status
 
-`dadmin status -o <org> -r <regex> --verbose`
+`gut status -o <org> -r <regex> --verbose`
 
 ### Effect
 
@@ -101,7 +101,7 @@ This command will try to show statuses of all local repositories that match a re
 
 ## Commit
 
-`dadmin commit -o <org> -r <regex> --message <message>`
+`gut commit -o <org> -r <regex> --message <message>`
 
 ### Effect
 
@@ -113,11 +113,11 @@ If there is no changes, this also will be aborted.
 ## Fetch
 
 ```
-dadmin-fetch 0.1.0
+gut-fetch 0.1.0
 Fetch all local repositories that match a regex
 
 USAGE:
-    dadmin fetch [OPTIONS]
+    gut fetch [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information
@@ -134,14 +134,14 @@ OPTIONS:
 Change visibilities of repositories
 
 ```
-dadmin-make 0.1.0
+gut-make 0.1.0
 Make repositories that match a regex become public/private
 
 This will show all repositories that will affected by this command If you want to public repositories, it'll show a
 confirmation prompt and You have to enter 'YES' to confirm your action
 
 USAGE:
-    dadmin make [OPTIONS] --regex <regex> <SUBCOMMAND>
+    gut make [OPTIONS] --regex <regex> <SUBCOMMAND>
 
 FLAGS:
     -h, --help       Prints help information
@@ -160,7 +160,7 @@ SUBCOMMANDS:
 ## Set info
 
 ```
-dadmin-set-info 0.1.0
+gut-set-info 0.1.0
 Set description and/or website for all repositories that match regex
 
 Description can be provided by --description option or --des-script option
@@ -170,7 +170,7 @@ When it is provided --des-script will override --description
 Similar to --web-script and --website
 
 USAGE:
-    dadmin set info [OPTIONS] --regex <regex>
+    gut set info [OPTIONS] --regex <regex>
 
 FLAGS:
     -h, --help       Prints help information
@@ -197,11 +197,11 @@ printf "This is the best description ever for ${name} in ${org}"
 ## Set secret
 
 ```
-dadmin-set-secret 0.1.0
+gut-set-secret 0.1.0
 Set a secret all repositories that match regex
 
 USAGE:
-    dadmin set secret [OPTIONS] --name <name> --regex <regex> --value <value>
+    gut set secret [OPTIONS] --name <name> --regex <regex> --value <value>
 
 FLAGS:
     -h, --help       Prints help information
@@ -217,11 +217,11 @@ OPTIONS:
 ## Topic
 
 ```
-dadmin-topic 0.1.0
+gut-topic 0.1.0
 Sub command for set/get/add topics
 
 USAGE:
-    dadmin topic <SUBCOMMAND>
+    gut topic <SUBCOMMAND>
 
 FLAGS:
     -h, --help       Prints help information
@@ -238,11 +238,11 @@ SUBCOMMANDS:
 ### Topic Get
 
 ```
-dadmin-topic-get 0.1.0
+gut-topic-get 0.1.0
 Get topics for all repositories that match a regex
 
 USAGE:
-    dadmin topic get [OPTIONS]
+    gut topic get [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information
@@ -257,11 +257,11 @@ OPTIONS:
 ### Topic Set
 
 ```
-dadmin-topic-set 0.1.0
+gut-topic-set 0.1.0
 Set topics for all repositories that match a regex
 
 USAGE:
-    dadmin topic set [OPTIONS]
+    gut topic set [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information
@@ -276,11 +276,11 @@ OPTIONS:
 ## Topic Add
 
 ```
-dadmin-topic-add 0.1.0
+gut-topic-add 0.1.0
 Add topics for all repositories that match a regex
 
 USAGE:
-    dadmin topic add [OPTIONS]
+    gut topic add [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information
@@ -295,12 +295,12 @@ OPTIONS:
 ## Topic Apply
 
 ```
-dadmin-topic-apply 0.1.0
+gut-topic-apply 0.1.0
 Apply a script to all repositories that has a topics that match a pattern Or to all repositories that has a specific
 topic
 
 USAGE:
-    dadmin topic apply [FLAGS] [OPTIONS] --regex <regex> --script <script> --topic <topic>
+    gut topic apply [FLAGS] [OPTIONS] --regex <regex> --script <script> --topic <topic>
 
 FLAGS:
     -h, --help         Prints help information
@@ -317,10 +317,10 @@ OPTIONS:
 ## Hook Create
 
 ```
-dadmin-hook-create 0.1.0
+gut-hook-create 0.1.0
 
 USAGE:
-    dadmin hook create [OPTIONS] --method <method> --regex <regex> --script <script> --url <url>
+    gut hook create [OPTIONS] --method <method> --regex <regex> --script <script> --url <url>
 
 FLAGS:
     -h, --help       Prints help information

--- a/doc/template/template.md
+++ b/doc/template/template.md
@@ -25,22 +25,22 @@ In order to apply changes from template. We need to read `delta` file from both 
 
 ### List of commands
 
-Let says `dadmin template` is our sub command for this task. Below are our list of commands:
+Let says `gut template` is our sub command for this task. Below are our list of commands:
 The bold one is nesscesary for our current task (apply changes).
 
 #### Template
 
-- `dadmin template init`: Init delta file for a template repo
-- `dadmin template bump-version`: Mark the current version of the template is the newest version of template
-- `dadmin template {add,remove} [--optional|--ignore]`: Adds or remove a file from the template list, with flags for adding to the optional or ignored list
-- `dadmin template pattern {list,add,remove}`: Manage file patterns (like UND -> some lang)
+- `gut template init`: Init delta file for a template repo
+- `gut template bump-version`: Mark the current version of the template is the newest version of template
+- `gut template {add,remove} [--optional|--ignore]`: Adds or remove a file from the template list, with flags for adding to the optional or ignored list
+- `gut template pattern {list,add,remove}`: Manage file patterns (like UND -> some lang)
 
 #### Repo
 
-- `dadmin generate-repo <template-url>`: Create a new repository from a template url
-- `dadmin template install <template-url>`: Init delta file for a repo
-- `dadmin template apply [--continue|--abort]`: Start apply changes from template - if conflict, running with --continue after starting will allow finishing it, and --abort will revert any patching changes.
-- `dadmin template replacement {set,remove}`: Add or remove replacements from the template file
+- `gut generate-repo <template-url>`: Create a new repository from a template url
+- `gut template install <template-url>`: Init delta file for a repo
+- `gut template apply [--continue|--abort]`: Start apply changes from template - if conflict, running with --continue after starting will allow finishing it, and --abort will revert any patching changes.
+- `gut template replacement {set,remove}`: Add or remove replacements from the template file
 
 ### Delta file structure
 
@@ -48,7 +48,7 @@ Please read samples of delta files (which have some comments).
 
 ### How do we do apply changes?
 
-1. Run `dadmin template apply`
+1. Run `gut template apply`
 2. Mark this process as in applying process
 3. Read delta files of both template and target repo.
 4. Determine the last changes (use rev_id)
@@ -58,4 +58,4 @@ Please read samples of delta files (which have some comments).
 8. Show status of this action (changes, conflicts, etc)
 9. Manually resolve conflict if needed
 10. Manually commit
-11. Run `dadmin template apply --continue` => Mark this process is done.
+11. Run `gut template apply --continue` => Mark this process is done.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use crate::commands::{
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "dadmin", about = "git multirepo maintenance tool")]
+#[structopt(name = "gut", about = "git multirepo maintenance tool")]
 pub struct Args {
     #[structopt(subcommand)]
     pub command: Commands,

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -24,7 +24,7 @@ impl ApplyArgs {
             .script
             .path
             .to_str()
-            .expect("dadmin only supports utf8 path now!");
+            .expect("gut only supports UTF-8 paths now!");
 
         for dir in sub_dirs {
             match common::apply_script(&dir, script_path) {

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -23,17 +23,17 @@ pub fn query_and_filter_repositories(
 
 pub fn user() -> Result<User> {
     User::user()
-        .context("Cannot get user token from the config file. Run dadmin init with a valid token")
+        .context("Cannot get user token from the config file. Run `gut init` with a valid token")
 }
 
 pub fn root() -> Result<String> {
     Config::root()
-        .context("Cannot read the config file. Run dadmin init with valid token and root directory")
+        .context("Cannot read the config file. Run `gut init` with valid token and root directory")
 }
 
 pub fn user_token() -> Result<String> {
     User::token()
-        .context("Cannot get user token from the config file. Run dadmin init with a valid token")
+        .context("Cannot get user token from the config file. Run `gut init` with a valid token")
 }
 
 fn remote_repos(token: &str, org: &str) -> Result<Vec<RemoteRepo>> {
@@ -44,7 +44,7 @@ fn remote_repos(token: &str, org: &str) -> Result<Vec<RemoteRepo>> {
                 anyhow::bail!("No repositories found");
             }
             if e.downcast_ref::<Unauthorized>().is_some() {
-                anyhow::bail!("User token invalid. Run dadmin init with a valid token");
+                anyhow::bail!("User token invalid. Run `gut init` with a valid token");
             }
             Err(e)
         }

--- a/src/commands/create_discussion.rs
+++ b/src/commands/create_discussion.rs
@@ -33,15 +33,15 @@ impl CreateDiscussionArgs {
             &token,
         ) {
             Ok(r) => println!(
-                "You created a team discussion for team {} at {}",
+                "You created a team discussion for team `{}` at {}",
                 self.team_slug, r.html_url
             ),
             Err(e) => {
                 if e.downcast_ref::<Unauthorized>().is_some() {
-                    anyhow::bail!("User token invalid. Run dadmin init with a valid token");
+                    anyhow::bail!("User token invalid. Run `gut init` with a valid token");
                 } else {
                     println!(
-                        "Failed to create a disscusion for team {} because of {}",
+                        "Failed to create a discussion for team `{}` because of {}",
                         self.team_slug, e
                     );
                 }

--- a/src/commands/create_team.rs
+++ b/src/commands/create_team.rs
@@ -29,7 +29,12 @@ impl CreateTeamArgs {
             "You created a team named: {} successfully with id: {} and link : {}",
             self.team_name, r.id, r.html_url
         ),
-            Err(e) => println!("Failed to create team named: {} because of {}\n. Please notice that you need to add users to your organisation before adding them to a team.", self.team_name, e)
+            Err(e) => println!(
+                "Failed to create team named: {} because of {}\n. \
+                Please notice that you need to add users to your organisation before adding them to a team.",
+                self.team_name,
+                e
+            )
         }
 
         Ok(())
@@ -51,7 +56,7 @@ fn create_team(args: &CreateTeamArgs, token: &str) -> Result<CreateTeamResponse>
         Ok(response) => Ok(response),
         Err(e) => {
             if e.downcast_ref::<Unauthorized>().is_some() {
-                anyhow::bail!("User token invalid. Run dadmin init with a valid token");
+                anyhow::bail!("User token invalid. Run `gut init` with a valid token");
             }
             Err(e)
         }

--- a/src/commands/models/root_directory.rs
+++ b/src/commands/models/root_directory.rs
@@ -34,9 +34,9 @@ impl Default for RootDirectory {
         RootDirectory {
             path: dirs::home_dir()
                 .expect("Cannot have unknown home directory")
-                .join("dadmin")
+                .join("gut")
                 .to_str()
-                .expect("Non UTF8 path is not supported right now")
+                .expect("gut only supports UTF-8 paths now!")
                 .to_string(),
         }
     }

--- a/src/commands/models/script.rs
+++ b/src/commands/models/script.rs
@@ -81,7 +81,7 @@ impl Script {
         let script_path = self
             .path
             .to_str()
-            .expect("gut only supports utf8 path now!");
+            .expect("gut only supports UTF-8 paths now!");
         Ok(script_path.to_string())
     }
 }

--- a/src/commands/topic_apply.rs
+++ b/src/commands/topic_apply.rs
@@ -37,7 +37,7 @@ impl TopicApplyArgs {
             .script
             .path
             .to_str()
-            .expect("dadmin only supports utf8 path now!");
+            .expect("gut only supports UTF-8 paths now!");
 
         let user = common::user()?;
         let repos = query_repositories_with_topics(&self.organisation, &user.token)?;
@@ -80,7 +80,7 @@ fn query_repositories_with_topics(org: &str, token: &str) -> Result<Vec<RemoteRe
                 anyhow::bail!("No repositories found");
             }
             if e.downcast_ref::<Unauthorized>().is_some() {
-                anyhow::bail!("User token invalid. Run dadmin init with a valid token");
+                anyhow::bail!("User token invalid. Run `gut init` with a valid token");
             }
             Err(e)
         }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 
 pub fn try_from_one(repo: RemoteRepo, user: &User, use_https: bool) -> Result<GitRepo> {
     let root = Config::root().context(
-        "Cannot read the config file. Run dadmin init with valid token and root directory",
+        "Cannot read the config file. Run `gut init` with valid token and root directory",
     )?;
 
     let local_path = local_path_repo(&repo.owner, &repo.name, &root);

--- a/src/github/graphql.rs
+++ b/src/github/graphql.rs
@@ -43,7 +43,7 @@ fn query<T: Serialize + ?Sized>(token: &str, body: &T) -> Result<req::Response, 
     client
         .post("https://api.github.com/graphql")
         .bearer_auth(token)
-        .header("User-Agent", "dadmin")
+        .header("User-Agent", super::USER_AGENT)
         .json(body)
         .send()
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -6,4 +6,4 @@ pub use graphql::*;
 pub use models::*;
 pub use rest::*;
 
-pub(crate) static USER_AGENT: &'static str = concat!("gut ", env!("CARGO_PKG_VERSION"));
+pub(crate) static USER_AGENT: &str = concat!("gut ", env!("CARGO_PKG_VERSION"));

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -5,3 +5,5 @@ pub mod rest;
 pub use graphql::*;
 pub use models::*;
 pub use rest::*;
+
+pub(crate) static USER_AGENT: &'static str = concat!("gut ", env!("CARGO_PKG_VERSION"));

--- a/src/github/rest.rs
+++ b/src/github/rest.rs
@@ -14,7 +14,7 @@ fn patch<T: Serialize + ?Sized>(
     client
         .patch(url)
         .bearer_auth(token)
-        .header("User-Agent", "dadmin")
+        .header("User-Agent", super::USER_AGENT)
         .header("Accept", "application/vnd.github.v3+json")
         .json(body)
         .send()
@@ -27,7 +27,7 @@ fn get(url: &str, token: &str, accept: Option<&str>) -> Result<req::Response, re
     client
         .get(url)
         .bearer_auth(token)
-        .header("User-Agent", "dadmin")
+        .header("User-Agent", super::USER_AGENT)
         .header("Accept", accept)
         .send()
 }
@@ -44,7 +44,7 @@ fn put<T: Serialize + ?Sized>(
     client
         .put(url)
         .bearer_auth(token)
-        .header("User-Agent", "dadmin")
+        .header("User-Agent", super::USER_AGENT)
         .header("Accept", accept)
         .json(body)
         .send()
@@ -60,7 +60,7 @@ fn post<T: Serialize + ?Sized>(
     client
         .post(url)
         .bearer_auth(token)
-        .header("User-Agent", "dadmin")
+        .header("User-Agent", super::USER_AGENT)
         .header("Accept", "application/vnd.github.v3+json")
         .json(body)
         .send()
@@ -72,7 +72,7 @@ fn delete(url: &str, token: &str) -> Result<req::Response, reqwest::Error> {
     client
         .delete(url)
         .bearer_auth(token)
-        .header("User-Agent", "dadmin")
+        .header("User-Agent", super::USER_AGENT)
         .header("Accept", "application/vnd.github.v3+json")
         .send()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<()> {
 
     pretty_env_logger::formatted_timed_builder()
         .filter(None, log::LevelFilter::Info)
-        .filter(Some("dadmin"), log::LevelFilter::Debug)
+        .filter(Some("gut"), log::LevelFilter::Debug)
         .init();
 
     let args = Args::from_args();

--- a/src/path.rs
+++ b/src/path.rs
@@ -4,7 +4,7 @@ use std::fs::{create_dir_all, write};
 use std::path::{Path, PathBuf};
 
 fn config_dir() -> Option<PathBuf> {
-    let config_dir = dirs::config_dir().map(|p| p.join("dadmin"))?;
+    let config_dir = dirs::config_dir().map(|p| p.join("gut"))?;
     let config_dir = config_dir.ensure_dir_exists().ok()?;
     Some(config_dir)
 }


### PR DESCRIPTION
#### Breaking change

Binary will be called `gut` after this, but it will also use that name when looking for config directories.

#### Drive by fixes

- Consistent spelling of UTF-8
- Move User Agent header value to a static in the module, and added the version. People like parsing those strings so why not give them something more?
- Updated dependencies. This gets rid of a bunch of duplicates but it shouldn't matter much.
