### PR TITLE
Implement workflow run command

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  repository_dispatch:
 
 jobs:
   check:

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -1,11 +1,6 @@
 name: Gut Check
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-  repository_dispatch:
+on: repository_dispatch
 
 jobs:
   check:

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -1,6 +1,10 @@
 name: Gut Check
 
-on: repository_dispatch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   check:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use crate::commands::{
     AddArgs, ApplyArgs, BranchArgs, CheckoutArgs, CiArgs, CleanArgs, CloneArgs, CommitArgs,
     CreateArgs, FetchArgs, HookArgs, InitArgs, InviteArgs, MakeArgs, MergeArgs, PullArgs, PushArgs,
-    RemoveArgs, SetArgs, ShowArgs, StatusArgs, TemplateArgs, TopicArgs, TransferArgs,
+    RemoveArgs, SetArgs, ShowArgs, StatusArgs, TemplateArgs, TopicArgs, TransferArgs, WorkflowArgs,
 };
 use structopt::StructOpt;
 
@@ -62,4 +62,6 @@ pub enum Commands {
     Topic(TopicArgs),
     #[structopt(name = "transfer")]
     Transfer(TransferArgs),
+    #[structopt(name = "workflow")]
+    Workflow(WorkflowArgs),
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,6 +49,8 @@ pub mod topic_get;
 pub mod topic_helper;
 pub mod topic_set;
 pub mod transfer;
+pub mod workflow;
+pub mod workflow_run;
 
 pub use add::*;
 pub use apply::*;
@@ -76,3 +78,4 @@ pub use status::*;
 pub use template::*;
 pub use topic::*;
 pub use transfer::*;
+pub use workflow::*;

--- a/src/commands/workflow.rs
+++ b/src/commands/workflow.rs
@@ -1,0 +1,17 @@
+use super::workflow_run::*;
+use anyhow::Result;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub enum WorkflowArgs {
+    #[structopt(name = "run")]
+    Run(WorkflowRunArgs),
+}
+
+impl WorkflowArgs {
+    pub fn run(&self) -> Result<()> {
+        match self {
+            WorkflowArgs::Run(args) => args.run(),
+        }
+    }
+}

--- a/src/commands/workflow_run.rs
+++ b/src/commands/workflow_run.rs
@@ -93,9 +93,8 @@ fn rerun_workflow(
         return Ok(Status::NoWorkflowRunFound);
     }
 
-    //let first_workflow = &workflow_runs[0];
-
-    //println!("First workflow {:?}", first_workflow);
+    let first_workflow = &workflow_runs[0];
+    github::rerun_a_workflow(repo, first_workflow.id, token)?;
 
     Ok(Status::Success)
 }

--- a/src/commands/workflow_run.rs
+++ b/src/commands/workflow_run.rs
@@ -1,0 +1,83 @@
+use super::common;
+
+use crate::filter::Filter;
+use crate::github;
+use crate::github::RemoteRepo;
+use anyhow::Result;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+/// Rerun the most recent workflow
+pub struct WorkflowRunArgs {
+    #[structopt(long, short, default_value = "divvun")]
+    pub organisation: String,
+    #[structopt(long, short)]
+    pub regex: Option<Filter>,
+    #[structopt(long, short)]
+    /// Optional workflow_file_name
+    pub workflow: Option<String>,
+}
+
+impl WorkflowRunArgs {
+    pub fn run(&self) -> Result<()> {
+        let user_token = common::user_token()?;
+        let filtered_repos = common::query_and_filter_repositories(
+            &self.organisation,
+            self.regex.as_ref(),
+            &user_token,
+        )?;
+
+        if filtered_repos.is_empty() {
+            println!(
+                "There is no repositories in organisation {} matches pattern {:?}",
+                self.organisation, self.regex
+            );
+            return Ok(());
+        }
+
+        for repo in filtered_repos {
+            let status = rerun_workflow(&repo, &user_token, self.workflow.as_deref());
+
+            match status {
+                Ok(s) => match s {
+                    Status::Success => println!(
+                        "Successful rerun the most recent workflow run for repo {}",
+                        repo.name
+                    ),
+                    Status::NoWorkflowRunFound => {
+                        println!("There is no workflow run in repo {}", repo.name)
+                    }
+                },
+                Err(e) => println!(
+                    "Failed to rerun workflow in repo {} because {:?}",
+                    repo.name, e
+                ),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn rerun_workflow(repo: &RemoteRepo, token: &str, workflow: Option<&str>) -> Result<Status> {
+    let workflow_runs = match workflow {
+        Some(wf) => github::get_workflow_runs(repo, wf, token)?,
+        None => github::get_repo_workflow_runs(repo, token)?,
+    };
+
+    if workflow_runs.is_empty() {
+        return Ok(Status::NoWorkflowRunFound);
+    }
+
+    let first_workflow = &workflow_runs[0];
+
+    println!("First workflow {:?}", first_workflow);
+    github::rerun_a_workflow(repo, first_workflow.id, token)?;
+
+    Ok(Status::Success)
+}
+
+enum Status {
+    NoWorkflowRunFound,
+    Success,
+}

--- a/src/commands/workflow_run.rs
+++ b/src/commands/workflow_run.rs
@@ -69,10 +69,10 @@ fn rerun_workflow(repo: &RemoteRepo, token: &str, workflow: Option<&str>) -> Res
         return Ok(Status::NoWorkflowRunFound);
     }
 
-    let first_workflow = &workflow_runs[0];
+    //let first_workflow = &workflow_runs[0];
 
-    println!("First workflow {:?}", first_workflow);
-    github::rerun_a_workflow(repo, first_workflow.id, token)?;
+    //println!("First workflow {:?}", first_workflow);
+    github::send_a_dspatch(repo, token)?;
 
     Ok(Status::Success)
 }

--- a/src/github/rest.rs
+++ b/src/github/rest.rs
@@ -774,10 +774,30 @@ pub struct Workflow {
     pub status: String,
 }
 
-pub fn rerun_a_workflow(repo: &RemoteRepo, id: usize, token: &str) -> Result<()> {
+//pub fn rerun_a_workflow(repo: &RemoteRepo, id: usize, token: &str) -> Result<()> {
+//let url = format!(
+//"https://api.github.com/repos/{}/{}/actions/runs/{}/rerun",
+//repo.owner, repo.name, id
+//);
+
+//println!("url {}", url);
+
+//let client = req::Client::new();
+//let response = client
+//.post(&url)
+//.bearer_auth(token)
+//.header("User-Agent", super::USER_AGENT)
+//.header("Accept", "application/vnd.github.v3+json")
+//.send()?;
+
+//println!("reruns {:?}", response);
+//process_response(&response).map(|_| ())
+//}
+
+pub fn send_a_dspatch(repo: &RemoteRepo, token: &str) -> Result<()> {
     let url = format!(
-        "https://api.github.com/repos/{}/{}/actions/runs/{}/rerun",
-        repo.owner, repo.name, id
+        "https://api.github.com/repos/{}/{}/dispatches",
+        repo.owner, repo.name
     );
 
     println!("url {}", url);
@@ -787,7 +807,7 @@ pub fn rerun_a_workflow(repo: &RemoteRepo, id: usize, token: &str) -> Result<()>
         .post(&url)
         .bearer_auth(token)
         .header("User-Agent", super::USER_AGENT)
-        .header("Accept", "application/vnd.github.v3+json")
+        .header("Accept", "application/vnd.github.everest-preview+json")
         .send()?;
 
     println!("reruns {:?}", response);

--- a/src/github/rest.rs
+++ b/src/github/rest.rs
@@ -774,27 +774,27 @@ pub struct Workflow {
     pub status: String,
 }
 
-//pub fn rerun_a_workflow(repo: &RemoteRepo, id: usize, token: &str) -> Result<()> {
-//let url = format!(
-//"https://api.github.com/repos/{}/{}/actions/runs/{}/rerun",
-//repo.owner, repo.name, id
-//);
+pub fn rerun_a_workflow(repo: &RemoteRepo, id: usize, token: &str) -> Result<()> {
+    let url = format!(
+        "https://api.github.com/repos/{}/{}/actions/runs/{}/rerun",
+        repo.owner, repo.name, id
+    );
 
-//println!("url {}", url);
+    println!("url {}", url);
 
-//let client = req::Client::new();
-//let response = client
-//.post(&url)
-//.bearer_auth(token)
-//.header("User-Agent", super::USER_AGENT)
-//.header("Accept", "application/vnd.github.v3+json")
-//.send()?;
+    let client = req::Client::new();
+    let response = client
+        .post(&url)
+        .bearer_auth(token)
+        .header("User-Agent", super::USER_AGENT)
+        .header("Accept", "application/vnd.github.v3+json")
+        .send()?;
 
-//println!("reruns {:?}", response);
-//process_response(&response).map(|_| ())
-//}
+    println!("reruns {:?}", response);
+    process_response(&response).map(|_| ())
+}
 
-pub fn send_a_dspatch(repo: &RemoteRepo, token: &str) -> Result<()> {
+pub fn send_a_dispatch(repo: &RemoteRepo, token: &str) -> Result<()> {
     let url = format!(
         "https://api.github.com/repos/{}/{}/dispatches",
         repo.owner, repo.name

--- a/src/github/rest.rs
+++ b/src/github/rest.rs
@@ -802,16 +802,18 @@ pub fn send_a_dspatch(repo: &RemoteRepo, token: &str) -> Result<()> {
 
     println!("url {}", url);
 
-    let client = req::Client::new();
-    let response = client
-        .post(&url)
-        .bearer_auth(token)
-        .header("User-Agent", super::USER_AGENT)
-        .header("Accept", "application/vnd.github.everest-preview+json")
-        .send()?;
+    let body = DispatchBody {
+        event_type: "repository_dispatch".to_string(),
+    };
 
+    let response = post(&url, &body, token)?;
     println!("reruns {:?}", response);
     process_response(&response).map(|_| ())
+}
+
+#[derive(Serialize, Debug)]
+struct DispatchBody {
+    event_type: String,
 }
 
 fn process_response(response: &req::Response) -> Result<&req::Response> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,5 +49,6 @@ fn main() -> Result<()> {
         Commands::Template(args) => args.run(),
         Commands::Topic(args) => args.run(),
         Commands::Transfer(args) => args.run(),
+        Commands::Workflow(args) => args.run(),
     }
 }


### PR DESCRIPTION
`cargo run -- workflow run --help `

```gut-workflow-run 0.1.0
Rerun the most recent workflow or send a repository_dispatch event to trigger workflows

Without "dispatch" flag this will try to re-run the most recent workflow. But This only works when the most recent
workflow failed.

With "dispatch" flag, this will send a repository_dispatch event to trigger supported workflows. In order to use this
option. The workflow files need to use repository_dispatch event. And this event will only trigger a workflow run if the
workflow file is on the master or default branch.

USAGE:
    gut workflow run [FLAGS] [OPTIONS]

FLAGS:
    -d, --dispatch    
            Send repository_dispatch to trigger workflow rerun

    -h, --help        
            Prints help information

    -V, --version     
            Prints version information


OPTIONS:
    -o, --organisation <organisation>    
             [default: divvun]

    -r, --regex <regex>                  
            

    -w, --workflow <workflow>            
            Optional workflow_file_name

```