### PR TITLE
Default organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ There are some [usage instructions](USAGE.md) under development.
 Then there are some use cases with example commands
 [here](https://github.com/divvun/giellalt-svn2git/blob/master/doc/GutUsageExamples.md).
 
-There is also some rudimentary help text. Run `gut -h` to get an overview.
+There is also some rudimentary help text. Run `gut --help` to get an overview.

--- a/src/commands/add_repos.rs
+++ b/src/commands/add_repos.rs
@@ -35,11 +35,8 @@ impl AddRepoArgs {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            self.regex.as_ref(),
-            &user.token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user.token)?;
 
         if filtered_repos.is_empty() {
             println!(

--- a/src/commands/add_repos.rs
+++ b/src/commands/add_repos.rs
@@ -9,9 +9,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Add all matched repositories to a team by using team_slug
 pub struct AddRepoArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -31,9 +33,10 @@ pub struct AddRepoArgs {
 impl AddRepoArgs {
     pub fn run(&self) -> Result<()> {
         let user = common::user()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             self.regex.as_ref(),
             &user.token,
         )?;
@@ -41,7 +44,7 @@ impl AddRepoArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} that matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/add_users.rs
+++ b/src/commands/add_users.rs
@@ -10,9 +10,11 @@ use structopt::StructOpt;
 ///
 /// If you specify team_slug it'll try to invite users to the provided team
 pub struct AddUsersArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short, default_value = "member")]
     /// Role of users
     ///
@@ -38,23 +40,25 @@ impl AddUsersArgs {
 
     fn add_users_to_org(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let users: Vec<String> = self.users.iter().map(|s| s.to_string()).collect();
 
-        let results = add_list_user_to_org(&self.organisation, &self.role, users, &user_token);
+        let results = add_list_user_to_org(&organisation, &self.role, users, &user_token);
 
-        print_results_org(&results, &self.organisation, &self.role);
+        print_results_org(&results, &organisation, &self.role);
 
         Ok(())
     }
 
     fn add_users_to_team(&self, team_name: &str) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let users: Vec<String> = self.users.iter().map(|s| s.to_string()).collect();
 
         let results = add_list_user_to_team(
-            &self.organisation,
+            &organisation,
             team_name,
             &self.role,
             users,

--- a/src/commands/add_users.rs
+++ b/src/commands/add_users.rs
@@ -57,13 +57,8 @@ impl AddUsersArgs {
 
         let users: Vec<String> = self.users.iter().map(|s| s.to_string()).collect();
 
-        let results = add_list_user_to_team(
-            &organisation,
-            team_name,
-            &self.role,
-            users,
-            &user_token,
-        );
+        let results =
+            add_list_user_to_team(&organisation, team_name, &self.role, users, &user_token);
 
         print_results_team(&results, team_name, &self.role);
 

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -7,9 +7,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Apply a script to all local repositories that match a pattern
 pub struct ApplyArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -21,7 +23,8 @@ pub struct ApplyArgs {
 impl ApplyArgs {
     pub fn run(&self) -> Result<()> {
         let root = common::root()?;
-        let sub_dirs = common::read_dirs_for_org(&self.organisation, &root, self.regex.as_ref())?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
+        let sub_dirs = common::read_dirs_for_org(&organisation, &root, self.regex.as_ref())?;
 
         let script_path = self
             .script

--- a/src/commands/branch_default.rs
+++ b/src/commands/branch_default.rs
@@ -10,9 +10,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Set a branch as default for all repositories that match a pattern
 pub struct DefaultBranchArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -24,8 +26,9 @@ pub struct DefaultBranchArgs {
 impl DefaultBranchArgs {
     pub fn set_default_branch(&self) -> Result<()> {
         let token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
         let repos =
-            common::query_and_filter_repositories(&self.organisation, self.regex.as_ref(), &token)?;
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &token)?;
 
         for repo in repos {
             let result = set_default_branch(&repo, &self.default_branch, &token);

--- a/src/commands/branch_protect.rs
+++ b/src/commands/branch_protect.rs
@@ -28,11 +28,8 @@ impl ProtectedBranchArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            self.regex.as_ref(),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user_token)?;
 
         for repo in filtered_repos {
             let result = set_protected_branch(&repo, &self.protected_branch, &user_token);

--- a/src/commands/branch_protect.rs
+++ b/src/commands/branch_protect.rs
@@ -10,9 +10,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Set a branch as protected for all local repositories that match a pattern
 pub struct ProtectedBranchArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -24,9 +26,10 @@ pub struct ProtectedBranchArgs {
 impl ProtectedBranchArgs {
     pub fn set_protected_branch(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             self.regex.as_ref(),
             &user_token,
         )?;

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -21,9 +21,11 @@ use crate::github::RemoteRepo;
 ///
 /// This command is able to clone a repository if it is not on the root directory
 pub struct CheckoutArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -47,9 +49,10 @@ pub struct CheckoutArgs {
 impl CheckoutArgs {
     pub fn run(&self) -> Result<()> {
         let user = common::user()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let all_repos =
-            topic_helper::query_repositories_with_topics(&self.organisation, &user.token)?;
+            topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
 
         let filtered_repos: Vec<_> =
             topic_helper::filter_repos(&all_repos, self.topic.as_ref(), self.regex.as_ref())
@@ -60,7 +63,7 @@ impl CheckoutArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} that matches pattern {:?} or topic {:?}",
-                self.organisation, self.regex, self.topic
+                organisation, self.regex, self.topic
             );
             return Ok(());
         }

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -51,8 +51,7 @@ impl CheckoutArgs {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let all_repos =
-            topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
+        let all_repos = topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
 
         let filtered_repos: Vec<_> =
             topic_helper::filter_repos(&all_repos, self.topic.as_ref(), self.regex.as_ref())

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -9,9 +9,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Do git clean -f for all local repositories that match a pattern
 pub struct CleanArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -20,7 +22,8 @@ pub struct CleanArgs {
 impl CleanArgs {
     pub fn run(&self) -> Result<()> {
         let root = common::root()?;
-        let sub_dirs = common::read_dirs_for_org(&self.organisation, &root, self.regex.as_ref())?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
+        let sub_dirs = common::read_dirs_for_org(&organisation, &root, self.regex.as_ref())?;
 
         for dir in sub_dirs {
             if let Err(e) = clean(&dir) {

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -16,9 +16,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Clone all repositories that matches a pattern
 pub struct CloneArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -30,9 +32,10 @@ pub struct CloneArgs {
 impl CloneArgs {
     pub fn run(&self) -> Result<()> {
         let user = common::user()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             self.regex.as_ref(),
             &user.token,
         )?;
@@ -40,7 +43,7 @@ impl CloneArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} matches pattern {:?}",
-                self.organisation, self.regex
+                &organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -34,11 +34,8 @@ impl CloneArgs {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            self.regex.as_ref(),
-            &user.token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user.token)?;
 
         if filtered_repos.is_empty() {
             println!(

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -14,9 +14,11 @@ use crate::user::User;
 /// Add all and then commit with the provided messages for all
 /// repositories that match a pattern or a topic
 pub struct CommitArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -33,9 +35,10 @@ pub struct CommitArgs {
 impl CommitArgs {
     pub fn run(&self) -> Result<()> {
         let user = common::user()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let all_repos =
-            topic_helper::query_repositories_with_topics(&self.organisation, &user.token)?;
+            topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
         let filtered_repos: Vec<_> =
             topic_helper::filter_repos(&all_repos, self.topic.as_ref(), self.regex.as_ref())
                 .into_iter()

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -37,8 +37,7 @@ impl CommitArgs {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let all_repos =
-            topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
+        let all_repos = topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
         let filtered_repos: Vec<_> =
             topic_helper::filter_repos(&all_repos, self.topic.as_ref(), self.regex.as_ref())
                 .into_iter()

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -37,6 +37,19 @@ pub fn user_token() -> Result<String> {
         .context("Cannot get user token from the config file. Run `gut init` with a valid token")
 }
 
+pub fn organisation(opt: Option<&str>) -> Result<String> {
+    match opt {
+        Some(s) => Ok(s.to_string()),
+        None => {
+            let config = Config::config()?;
+            match config.default_org {
+                Some(o) => Ok(o),
+                None => anyhow::bail!("You need to provide an organisation or set a default organisation with init/set default organisation command."),
+            }
+        }
+    }
+}
+
 fn remote_repos(token: &str, org: &str) -> Result<Vec<RemoteRepo>> {
     match github::list_org_repos(token, org).context("When fetching repositories") {
         Ok(repos) => Ok(repos),

--- a/src/commands/create_branch.rs
+++ b/src/commands/create_branch.rs
@@ -51,8 +51,7 @@ impl CreateBranchArgs {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let all_repos =
-            topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
+        let all_repos = topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
         let filtered_repos: Vec<_> =
             topic_helper::filter_repos(&all_repos, self.topic.as_ref(), self.regex.as_ref())
                 .into_iter()

--- a/src/commands/create_branch.rs
+++ b/src/commands/create_branch.rs
@@ -21,9 +21,11 @@ use structopt::StructOpt;
 /// The new branch will be based from a another branch (default is master).
 /// If a matched repository is not present in root dir yet, it will be cloned.
 pub struct CreateBranchArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short, required_unless("topic"))]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -47,9 +49,10 @@ pub struct CreateBranchArgs {
 impl CreateBranchArgs {
     pub fn run(&self) -> Result<()> {
         let user = common::user()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let all_repos =
-            topic_helper::query_repositories_with_topics(&self.organisation, &user.token)?;
+            topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
         let filtered_repos: Vec<_> =
             topic_helper::filter_repos(&all_repos, self.topic.as_ref(), self.regex.as_ref())
                 .into_iter()
@@ -59,7 +62,7 @@ impl CreateBranchArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/create_discussion.rs
+++ b/src/commands/create_discussion.rs
@@ -9,9 +9,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Create a discussion for a team in an organisation
 pub struct CreateDiscussionArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Team slug
     pub team_slug: String,
@@ -29,9 +31,10 @@ pub struct CreateDiscussionArgs {
 impl CreateDiscussionArgs {
     pub fn create_discusstion(&self) -> Result<()> {
         let token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         match github::create_discusstion(
-            &self.organisation,
+            &organisation,
             &self.team_slug,
             &self.subject,
             &self.body,

--- a/src/commands/create_team.rs
+++ b/src/commands/create_team.rs
@@ -9,9 +9,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Create a new team for an organisation
 pub struct CreateTeamArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Team name
     pub team_name: String,
@@ -51,8 +53,10 @@ fn create_team(args: &CreateTeamArgs, token: &str) -> Result<CreateTeamResponse>
     let empty = &"".to_string();
     let des: &str = args.description.as_ref().unwrap_or(empty);
     let members: Vec<String> = args.members.iter().map(|s| s.to_string()).collect();
+    let organisation = common::organisation(args.organisation.as_deref())?;
+
     match github::create_team(
-        &args.organisation,
+        &organisation,
         &args.team_name,
         des,
         members,

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -13,9 +13,11 @@ use structopt::StructOpt;
 ///
 /// This command only works on those repositories that has been cloned in root directory
 pub struct FetchArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -25,7 +27,9 @@ impl FetchArgs {
     pub fn run(&self) -> Result<()> {
         let user = common::user()?;
         let root = common::root()?;
-        let sub_dirs = common::read_dirs_for_org(&self.organisation, &root, self.regex.as_ref())?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
+
+        let sub_dirs = common::read_dirs_for_org(&organisation, &root, self.regex.as_ref())?;
 
         for dir in sub_dirs {
             fetch(&dir, &user)?;

--- a/src/commands/hook_create.rs
+++ b/src/commands/hook_create.rs
@@ -79,11 +79,8 @@ impl CreateArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            Some(&self.regex),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, Some(&self.regex), &user_token)?;
 
         if filtered_repos.is_empty() {
             println!(

--- a/src/commands/hook_create.rs
+++ b/src/commands/hook_create.rs
@@ -13,9 +13,11 @@ use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct CreateArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Filter,
@@ -75,9 +77,10 @@ impl Method {
 impl CreateArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             Some(&self.regex),
             &user_token,
         )?;
@@ -85,7 +88,7 @@ impl CreateArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/hook_delete.rs
+++ b/src/commands/hook_delete.rs
@@ -26,11 +26,8 @@ impl DeleteArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            Some(&self.regex),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, Some(&self.regex), &user_token)?;
 
         if filtered_repos.is_empty() {
             println!(

--- a/src/commands/hook_delete.rs
+++ b/src/commands/hook_delete.rs
@@ -11,9 +11,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Delete all web hooks for all repository that match regex
 pub struct DeleteArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Filter,
@@ -22,9 +24,10 @@ pub struct DeleteArgs {
 impl DeleteArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             Some(&self.regex),
             &user_token,
         )?;
@@ -32,7 +35,7 @@ impl DeleteArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/init_config.rs
+++ b/src/commands/init_config.rs
@@ -15,6 +15,9 @@ pub struct InitArgs {
     #[structopt(short, long)]
     /// Github token. Gut needs github token to access your github data
     pub token: String,
+    /// Default organisation
+    #[structopt(short, long)]
+    pub organisation: Option<String>,
 }
 
 impl InitArgs {
@@ -27,7 +30,7 @@ impl InitArgs {
                 }
             };
         user.save_user()?;
-        let config = Config::new(self.root.path.clone());
+        let config = Config::new(self.root.path.clone(), self.organisation.clone());
         config.save_config()
     }
 }

--- a/src/commands/invite_users.rs
+++ b/src/commands/invite_users.rs
@@ -86,12 +86,8 @@ impl InviteUsersArgs {
 
         let emails: Vec<String> = self.emails.iter().map(|s| s.to_string()).collect();
 
-        let results = add_list_user_to_org(
-            &organisation,
-            &self.role.to_value(),
-            emails,
-            &user_token,
-        );
+        let results =
+            add_list_user_to_org(&organisation, &self.role.to_value(), emails, &user_token);
 
         print_results_org(&results, &organisation, &self.role.to_value());
 

--- a/src/commands/invite_users.rs
+++ b/src/commands/invite_users.rs
@@ -10,9 +10,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Invite users to an organisation by emails
 pub struct InviteUsersArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short, default_value)]
     /// Role of users
     /// It should be one of ["member", "admin", "billing_manager"]
@@ -80,17 +82,18 @@ impl fmt::Display for Role {
 impl InviteUsersArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let emails: Vec<String> = self.emails.iter().map(|s| s.to_string()).collect();
 
         let results = add_list_user_to_org(
-            &self.organisation,
+            &organisation,
             &self.role.to_value(),
             emails,
             &user_token,
         );
 
-        print_results_org(&results, &self.organisation, &self.role.to_value());
+        print_results_org(&results, &organisation, &self.role.to_value());
 
         Ok(())
     }

--- a/src/commands/make.rs
+++ b/src/commands/make.rs
@@ -60,11 +60,8 @@ impl MakeArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            Some(&self.regex),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, Some(&self.regex), &user_token)?;
 
         let is_private = self.visibility.is_private();
 

--- a/src/commands/make.rs
+++ b/src/commands/make.rs
@@ -1,4 +1,5 @@
 use super::common;
+
 use crate::filter::Filter;
 use crate::github;
 use anyhow::Result;
@@ -14,9 +15,11 @@ use structopt::StructOpt;
 pub struct MakeArgs {
     #[structopt(flatten)]
     pub visibility: Visibility,
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Regex to filter repositories
     pub regex: Filter,
@@ -55,9 +58,10 @@ impl fmt::Display for Visibility {
 impl MakeArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             Some(&self.regex),
             &user_token,
         )?;
@@ -67,7 +71,7 @@ impl MakeArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} that matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -9,9 +9,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Merge a branch to the current branch for all repositories that match a pattern
 pub struct MergeArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -26,7 +28,9 @@ pub struct MergeArgs {
 impl MergeArgs {
     pub fn run(&self) -> Result<()> {
         let root = common::root()?;
-        let sub_dirs = common::read_dirs_for_org(&self.organisation, &root, self.regex.as_ref())?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
+
+        let sub_dirs = common::read_dirs_for_org(&organisation, &root, self.regex.as_ref())?;
 
         for dir in sub_dirs {
             match merge(&dir, &self.branch, self.abort_if_conflict) {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -33,6 +33,7 @@ pub mod remove;
 pub mod remove_repos;
 pub mod remove_users;
 pub mod set;
+pub mod set_default_organisation;
 pub mod set_info;
 pub mod set_secret;
 pub mod set_team_permission;

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -20,7 +20,9 @@ use structopt::StructOpt;
 pub struct PullArgs {
     #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -33,12 +35,14 @@ impl PullArgs {
     pub fn run(&self) -> Result<()> {
         let user = common::user()?;
         let root = common::root()?;
-        let sub_dirs = common::read_dirs_for_org(&self.organisation, &root, self.regex.as_ref())?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
+
+        let sub_dirs = common::read_dirs_for_org(&organisation, &root, self.regex.as_ref())?;
 
         if sub_dirs.is_empty() {
             println!(
                 "There is no local repositories in organisation {} matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -44,8 +44,7 @@ impl PushArgs {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let all_repos =
-            topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
+        let all_repos = topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
 
         let filtered_repos: Vec<_> =
             topic_helper::filter_repos(&all_repos, self.topic.as_ref(), self.regex.as_ref())

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -22,9 +22,11 @@ use rayon::prelude::*;
 ///
 /// This command will do nothing if there is nothing to push
 pub struct PushArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -40,9 +42,10 @@ pub struct PushArgs {
 impl PushArgs {
     pub fn run(&self) -> Result<()> {
         let user = common::user()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let all_repos =
-            topic_helper::query_repositories_with_topics(&self.organisation, &user.token)?;
+            topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
 
         let filtered_repos: Vec<_> =
             topic_helper::filter_repos(&all_repos, self.topic.as_ref(), self.regex.as_ref())
@@ -53,7 +56,7 @@ impl PushArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/remove_repos.rs
+++ b/src/commands/remove_repos.rs
@@ -8,18 +8,23 @@ use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct RemoveReposArgs {
-    #[structopt(long, short, default_value = "divvun")]
-    pub organisation: String,
     #[structopt(long, short)]
+    /// Target organisation name
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
+    #[structopt(long, short)]
+    /// Optional regex to filter repositories
     pub regex: Option<Filter>,
 }
 
 impl RemoveReposArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             self.regex.as_ref(),
             &user_token,
         )?;
@@ -27,7 +32,7 @@ impl RemoveReposArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/remove_repos.rs
+++ b/src/commands/remove_repos.rs
@@ -23,11 +23,8 @@ impl RemoveReposArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            self.regex.as_ref(),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user_token)?;
 
         if filtered_repos.is_empty() {
             println!(

--- a/src/commands/remove_users.rs
+++ b/src/commands/remove_users.rs
@@ -10,9 +10,11 @@ use structopt::StructOpt;
 ///
 /// If you specify team_slug it'll try to remove users from the provided team
 pub struct RemoveUsersArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// List of user's username
     pub users: Vec<String>,
@@ -31,22 +33,24 @@ impl RemoveUsersArgs {
 
     fn remove_users_from_org(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let users: Vec<String> = self.users.iter().map(|s| s.to_string()).collect();
 
-        let results = remove_list_user_from_org(&self.organisation, users, &user_token);
+        let results = remove_list_user_from_org(&organisation, users, &user_token);
 
-        print_results_org(&results, &self.organisation);
+        print_results_org(&results, &organisation);
 
         Ok(())
     }
 
     fn remove_users_from_team(&self, team_name: &str) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let users: Vec<String> = self.users.iter().map(|s| s.to_string()).collect();
 
-        let results = remove_list_user_from_team(&self.organisation, team_name, users, &user_token);
+        let results = remove_list_user_from_team(&organisation, team_name, users, &user_token);
 
         print_results_team(&results, team_name);
 

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -1,4 +1,5 @@
 use super::set_info::*;
+use super::set_default_organisation::*;
 use super::set_secret::*;
 use super::set_team_permission::*;
 use anyhow::Result;
@@ -9,6 +10,8 @@ use structopt::StructOpt;
 pub enum SetArgs {
     #[structopt(name = "info")]
     Info(InfoArgs),
+    #[structopt(name = "organisation")]
+    Organisation(SetOrganisationArgs),
     #[structopt(name = "permission")]
     Permission(SetTeamPermissionArgs),
     #[structopt(name = "secret")]
@@ -19,6 +22,7 @@ impl SetArgs {
     pub fn run(&self) -> Result<()> {
         match self {
             SetArgs::Info(args) => args.run(),
+            SetArgs::Organisation(args) => args.run(),
             SetArgs::Permission(args) => args.set_permission(),
             SetArgs::Secret(args) => args.run(),
         }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -1,5 +1,5 @@
-use super::set_info::*;
 use super::set_default_organisation::*;
+use super::set_info::*;
 use super::set_secret::*;
 use super::set_team_permission::*;
 use anyhow::Result;

--- a/src/commands/set_default_organisation.rs
+++ b/src/commands/set_default_organisation.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-/// Set default organisation name
+/// Set default organisation name for every other command
 pub struct SetOrganisationArgs {
     /// Organisation name
     #[structopt(short, long)]

--- a/src/commands/set_default_organisation.rs
+++ b/src/commands/set_default_organisation.rs
@@ -1,0 +1,19 @@
+use crate::config::Config;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+/// Set default organisation name
+pub struct SetOrganisationArgs {
+    /// Organisation name
+    #[structopt(short, long)]
+    pub organisation: String,
+}
+
+impl SetOrganisationArgs {
+    pub fn run(&self) -> anyhow::Result<()> {
+        let mut config = Config::config()?;
+        config.default_org = Some(self.organisation.clone());
+        config.save_config()
+    }
+}
+

--- a/src/commands/set_default_organisation.rs
+++ b/src/commands/set_default_organisation.rs
@@ -16,4 +16,3 @@ impl SetOrganisationArgs {
         config.save_config()
     }
 }
-

--- a/src/commands/set_info.rs
+++ b/src/commands/set_info.rs
@@ -17,9 +17,11 @@ use structopt::StructOpt;
 ///
 /// Similar to --web-script and --website
 pub struct InfoArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Filter,
@@ -40,9 +42,10 @@ pub struct InfoArgs {
 impl InfoArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             Some(&self.regex),
             &user_token,
         )?;

--- a/src/commands/set_info.rs
+++ b/src/commands/set_info.rs
@@ -44,11 +44,8 @@ impl InfoArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            Some(&self.regex),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, Some(&self.regex), &user_token)?;
 
         for repo in filtered_repos {
             let result = set_info(&repo, &self, &user_token);

--- a/src/commands/set_secret.rs
+++ b/src/commands/set_secret.rs
@@ -10,9 +10,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Set a secret all repositories that match regex
 pub struct SecretArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Filter,
@@ -27,9 +29,10 @@ pub struct SecretArgs {
 impl SecretArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             Some(&self.regex),
             &user_token,
         )?;

--- a/src/commands/set_secret.rs
+++ b/src/commands/set_secret.rs
@@ -31,11 +31,8 @@ impl SecretArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            Some(&self.regex),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, Some(&self.regex), &user_token)?;
 
         for repo in filtered_repos {
             let result = set_secret(&repo, &self.value, &self.name, &user_token);

--- a/src/commands/set_team_permission.rs
+++ b/src/commands/set_team_permission.rs
@@ -33,11 +33,8 @@ impl SetTeamPermissionArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            self.regex.as_ref(),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user_token)?;
 
         for repo in filtered_repos {
             let result = github::set_team_permission(

--- a/src/commands/set_team_permission.rs
+++ b/src/commands/set_team_permission.rs
@@ -8,9 +8,11 @@ use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct SetTeamPermissionArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -29,16 +31,17 @@ pub struct SetTeamPermissionArgs {
 impl SetTeamPermissionArgs {
     pub fn set_permission(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             self.regex.as_ref(),
             &user_token,
         )?;
 
         for repo in filtered_repos {
             let result = github::set_team_permission(
-                &self.organisation,
+                &organisation,
                 &self.team_slug,
                 &repo.owner,
                 &repo.name,

--- a/src/commands/show_repos.rs
+++ b/src/commands/show_repos.rs
@@ -21,11 +21,8 @@ impl ShowReposArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            self.regex.as_ref(),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user_token)?;
 
         print_results(&filtered_repos);
 

--- a/src/commands/show_repos.rs
+++ b/src/commands/show_repos.rs
@@ -6,9 +6,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 // Show all repositories that match a pattern
 pub struct ShowReposArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -17,9 +19,10 @@ pub struct ShowReposArgs {
 impl ShowReposArgs {
     pub fn show(&self) -> anyhow::Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             self.regex.as_ref(),
             &user_token,
         )?;

--- a/src/commands/show_users.rs
+++ b/src/commands/show_users.rs
@@ -6,9 +6,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Show all users in an organisation
 pub struct ShowUsersArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     //#[structopt(long, short, default_value = "all", parse(try_from_str = parse_role))]
     // Filter members returned by their role.
     //
@@ -22,8 +24,9 @@ pub struct ShowUsersArgs {
 impl ShowUsersArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let result = github::get_org_members(&self.organisation, &user_token);
+        let result = github::get_org_members(&organisation, &user_token);
 
         match result {
             Ok(users) => print_results(&users),

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -12,9 +12,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Show git status of all repositories that match a pattern
 pub struct StatusArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -26,7 +28,9 @@ pub struct StatusArgs {
 impl StatusArgs {
     pub fn run(&self) -> Result<()> {
         let root = common::root()?;
-        let sub_dirs = common::read_dirs_for_org(&self.organisation, &root, self.regex.as_ref())?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
+
+        let sub_dirs = common::read_dirs_for_org(&organisation, &root, self.regex.as_ref())?;
 
         let statuses: Vec<_> = sub_dirs.par_iter().map(|d| status(&d)).collect();
         let statuses: Result<Vec<_>> = statuses.into_par_iter().collect();

--- a/src/commands/topic_add.rs
+++ b/src/commands/topic_add.rs
@@ -7,9 +7,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Add topics for all repositories that match a regex
 pub struct TopicAddArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -21,9 +23,10 @@ pub struct TopicAddArgs {
 impl TopicAddArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             self.regex.as_ref(),
             &user_token,
         )?;
@@ -31,7 +34,7 @@ impl TopicAddArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} that matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/topic_add.rs
+++ b/src/commands/topic_add.rs
@@ -25,11 +25,8 @@ impl TopicAddArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            self.regex.as_ref(),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user_token)?;
 
         if filtered_repos.is_empty() {
             println!(

--- a/src/commands/topic_apply.rs
+++ b/src/commands/topic_apply.rs
@@ -12,9 +12,11 @@ use structopt::StructOpt;
 /// Or to all repositories that has a specific topic
 #[derive(Debug, StructOpt)]
 pub struct TopicApplyArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     /// regex pattern to filter topics. This is required unless topic is provided.
     #[structopt(long, short, required_unless("topic"))]
     pub regex: Option<Filter>,
@@ -40,7 +42,9 @@ impl TopicApplyArgs {
             .expect("gut only supports UTF-8 paths now!");
 
         let user = common::user()?;
-        let repos = topic_helper::query_repositories_with_topics(&self.organisation, &user.token)?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
+
+        let repos = topic_helper::query_repositories_with_topics(&organisation, &user.token)?;
         let repos =
             topic_helper::filter_repos_by_topics(&repos, self.topic.as_ref(), self.regex.as_ref());
 

--- a/src/commands/topic_get.rs
+++ b/src/commands/topic_get.rs
@@ -7,9 +7,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Get topics for all repositories that match a regex
 pub struct TopicGetArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -18,9 +20,10 @@ pub struct TopicGetArgs {
 impl TopicGetArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             self.regex.as_ref(),
             &user_token,
         )?;
@@ -28,7 +31,7 @@ impl TopicGetArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} that matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/topic_get.rs
+++ b/src/commands/topic_get.rs
@@ -22,11 +22,8 @@ impl TopicGetArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            self.regex.as_ref(),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user_token)?;
 
         if filtered_repos.is_empty() {
             println!(

--- a/src/commands/topic_set.rs
+++ b/src/commands/topic_set.rs
@@ -25,11 +25,8 @@ impl TopicSetArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            self.regex.as_ref(),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user_token)?;
 
         if filtered_repos.is_empty() {
             println!(

--- a/src/commands/topic_set.rs
+++ b/src/commands/topic_set.rs
@@ -7,9 +7,11 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 /// Set topics for all repositories that match a regex
 pub struct TopicSetArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -21,9 +23,10 @@ pub struct TopicSetArgs {
 impl TopicSetArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             self.regex.as_ref(),
             &user_token,
         )?;
@@ -31,7 +34,7 @@ impl TopicSetArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} that matches pattern {:?}",
-                self.organisation, self.regex
+                &organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -10,9 +10,11 @@ use structopt::StructOpt;
 /// This will show all repositories that will affected by this command
 /// You have to enter 'YES' to confirm your action
 pub struct TransferArgs {
-    #[structopt(long, short, default_value = "divvun")]
-    /// Current organisation name
-    pub organisation: String,
+    #[structopt(long, short)]
+    /// The current organisation name
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Regex to filter repositories
     pub regex: Filter,
@@ -24,9 +26,10 @@ pub struct TransferArgs {
 impl TransferArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
 
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             Some(&self.regex),
             &user_token,
         )?;
@@ -34,7 +37,7 @@ impl TransferArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} that matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -28,11 +28,8 @@ impl TransferArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            Some(&self.regex),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, Some(&self.regex), &user_token)?;
 
         if filtered_repos.is_empty() {
             println!(

--- a/src/commands/workflow_run.rs
+++ b/src/commands/workflow_run.rs
@@ -15,9 +15,11 @@ use structopt::StructOpt;
 /// In order to use this option. The workflow files need to use repository_dispatch event.
 /// And this event will only trigger a workflow run if the workflow file is on the master or default branch.
 pub struct WorkflowRunArgs {
-    #[structopt(long, short, default_value = "divvun")]
+    #[structopt(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    ///
+    /// You can set a default organisation in the init or set organisation command.
+    pub organisation: Option<String>,
     #[structopt(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -32,8 +34,10 @@ pub struct WorkflowRunArgs {
 impl WorkflowRunArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::organisation(self.organisation.as_deref())?;
+
         let filtered_repos = common::query_and_filter_repositories(
-            &self.organisation,
+            &organisation,
             self.regex.as_ref(),
             &user_token,
         )?;
@@ -41,7 +45,7 @@ impl WorkflowRunArgs {
         if filtered_repos.is_empty() {
             println!(
                 "There is no repositories in organisation {} matches pattern {:?}",
-                self.organisation, self.regex
+                organisation, self.regex
             );
             return Ok(());
         }

--- a/src/commands/workflow_run.rs
+++ b/src/commands/workflow_run.rs
@@ -36,11 +36,8 @@ impl WorkflowRunArgs {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
-        let filtered_repos = common::query_and_filter_repositories(
-            &organisation,
-            self.regex.as_ref(),
-            &user_token,
-        )?;
+        let filtered_repos =
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user_token)?;
 
         if filtered_repos.is_empty() {
             println!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,12 +6,13 @@ use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Config {
-    root: String,
+    pub root: String,
+    pub default_org: Option<String>,
 }
 
 impl Config {
-    pub fn new(root: String) -> Config {
-        Config { root }
+    pub fn new(root: String, default_org: Option<String>) -> Config {
+        Config { root , default_org }
     }
 
     pub fn save_config(&self) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ pub struct Config {
 
 impl Config {
     pub fn new(root: String, default_org: Option<String>) -> Config {
-        Config { root , default_org }
+        Config { root, default_org }
     }
 
     pub fn save_config(&self) -> Result<()> {


### PR DESCRIPTION
* Remove divvun as the default organisation for most of the commands
* Implement `set organisation -o <org>` command to set a default organisation
* User can set a default organisation by using `init` or `set organisation` command

Close #147 