### PR TITLE
Support auth token in apply command

### DIFF
--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -36,7 +36,6 @@ impl ApplyArgs {
         let organisation = common::organisation(self.organisation.as_deref())?;
         let sub_dirs = common::read_dirs_for_org(&organisation, &root, self.regex.as_ref())?;
 
-
         // set auth_token to env
         let user_token = common::user_token()?;
         let key = "GUT_TOKEN";

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -6,12 +6,16 @@ use anyhow::{Error, Result};
 use colored::*;
 use prettytable::{cell, format, row, Cell, Row, Table};
 use rayon::prelude::*;
+use std::env;
 use std::path::PathBuf;
 use std::process::Output;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 /// Apply a script to all local repositories that match a pattern
+///
+/// If you want your script to use your authentication token, you
+/// can refer to it in your script with $GUT_TOKEN
 pub struct ApplyArgs {
     #[structopt(long, short)]
     /// Target organisation name
@@ -31,6 +35,12 @@ impl ApplyArgs {
         let root = common::root()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
         let sub_dirs = common::read_dirs_for_org(&organisation, &root, self.regex.as_ref())?;
+
+
+        // set auth_token to env
+        let user_token = common::user_token()?;
+        let key = "GUT_TOKEN";
+        env::set_var(key, &user_token);
 
         if sub_dirs.is_empty() {
             println!(


### PR DESCRIPTION
Close #171 

If you want your script to use your authentication token, you can refer to it in your script with $GUT_TOKEN

Example:

If you have a script file `script.sh` with content:

```
echo $GUT_TOKEN
```

The result of `cargo run -- apply --script script.sh` will be:

```
+-------------------------------------------------------------+
| Repo      Status   Output                                   |
+=============================================================+
| rep      Success  {your_github_token}                       |
+-------------------------------------------------------------+

Applied the script for 1 repos successfully

There is no error!
```