### PR TITLE
[WIP] Add optional --format common argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 toml = "0.7.3"
 serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 clap = { version = "4.2", features = ["derive"] }
 thiserror = "1.0.40"
 anyhow = "1.0.70"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,16 +4,26 @@ use crate::commands::{
     RemoveArgs, RenameArgs, SetArgs, ShowArgs, StatusArgs, TemplateArgs, TopicArgs, TransferArgs,
     WorkflowArgs,
 };
-use clap::Parser;
+use clap::{Parser, ValueEnum, Subcommand};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum OutputFormat {
+    /// Output results as an ascii table
+    Table,
+    /// Output results as a json-serialised string
+    Json,
+}
 
 #[derive(Debug, Parser)]
 #[command(name = "gut", about = "git multirepo maintenance tool")]
 pub struct Args {
+    #[arg(long, value_enum, default_value = "table")]
+    pub format: Option<OutputFormat>,
     #[command(subcommand)]
     pub command: Commands,
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Subcommand)]
 pub enum Commands {
     #[command(name = "add")]
     Add(AddArgs),

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -2,6 +2,7 @@ use super::add_repos::*;
 use super::add_users::*;
 use anyhow::Result;
 use clap::Parser;
+use crate::cli::Args as CommonArgs;
 
 #[derive(Debug, Parser)]
 /// Add users, repos to an organisation/a team.
@@ -11,8 +12,8 @@ pub struct AddArgs {
 }
 
 impl AddArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -25,10 +26,10 @@ pub enum AddCommand {
 }
 
 impl AddCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            AddCommand::Users(args) => args.run(),
-            AddCommand::Repos(args) => args.run(),
+            AddCommand::Users(args) => args.run(common_args),
+            AddCommand::Repos(args) => args.run(common_args),
         }
     }
 }

--- a/src/commands/add_repos.rs
+++ b/src/commands/add_repos.rs
@@ -1,4 +1,5 @@
 use super::common;
+use crate::cli::Args as CommonArgs;
 use crate::filter::Filter;
 use crate::github;
 use crate::github::RemoteRepo;
@@ -33,7 +34,7 @@ pub struct AddRepoArgs {
 }
 
 impl AddRepoArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/add_users.rs
+++ b/src/commands/add_users.rs
@@ -1,5 +1,6 @@
 use super::common;
 use crate::github;
+use crate::cli::Args as CommonArgs;
 
 use anyhow::Result;
 
@@ -31,7 +32,7 @@ pub struct AddUsersArgs {
 }
 
 impl AddUsersArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         match &self.team_slug {
             Some(name) => self.add_users_to_team(name),
             None => self.add_users_to_org(),

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -1,6 +1,7 @@
 use super::common;
 use super::models::Script;
 use crate::filter::Filter;
+use crate::cli::Args as CommonArgs;
 use crate::path;
 use anyhow::{Error, Result};
 use clap::Parser;
@@ -31,7 +32,7 @@ pub struct ApplyArgs {
 }
 
 impl ApplyArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let root = common::root()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
         let sub_dirs = common::read_dirs_for_org(&organisation, &root, self.regex.as_ref())?;

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -3,6 +3,7 @@ use super::branch_protect::*;
 use super::branch_unprotect::*;
 use anyhow::Result;
 use clap::Parser;
+use crate::cli::Args as CommonArgs;
 
 #[derive(Debug, Parser)]
 /// Set default, set protected branch
@@ -12,8 +13,8 @@ pub struct BranchArgs {
 }
 
 impl BranchArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -28,11 +29,11 @@ pub enum BranchCommand {
 }
 
 impl BranchCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            BranchCommand::Default(args) => args.set_default_branch(),
-            BranchCommand::Protect(args) => args.set_protected_branch(),
-            BranchCommand::Unprotect(args) => args.set_unprotected_branch(),
+            BranchCommand::Default(args) => args.set_default_branch(common_args),
+            BranchCommand::Protect(args) => args.set_protected_branch(common_args),
+            BranchCommand::Unprotect(args) => args.set_unprotected_branch(common_args),
         }
     }
 }

--- a/src/commands/branch_default.rs
+++ b/src/commands/branch_default.rs
@@ -2,6 +2,7 @@ use super::common;
 use crate::filter::Filter;
 use crate::github;
 use crate::github::RemoteRepo;
+use crate::cli::Args as CommonArgs;
 
 use anyhow::Result;
 
@@ -24,7 +25,7 @@ pub struct DefaultBranchArgs {
 }
 
 impl DefaultBranchArgs {
-    pub fn set_default_branch(&self) -> Result<()> {
+    pub fn set_default_branch(&self, _common_args: &CommonArgs) -> Result<()> {
         let token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
         let repos =

--- a/src/commands/branch_protect.rs
+++ b/src/commands/branch_protect.rs
@@ -1,4 +1,5 @@
 use super::common;
+use crate::cli::Args as CommonArgs;
 use crate::github;
 use crate::github::RemoteRepo;
 
@@ -24,7 +25,7 @@ pub struct ProtectedBranchArgs {
 }
 
 impl ProtectedBranchArgs {
-    pub fn set_protected_branch(&self) -> Result<()> {
+    pub fn set_protected_branch(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/branch_unprotect.rs
+++ b/src/commands/branch_unprotect.rs
@@ -1,4 +1,5 @@
 use super::common;
+use crate::cli::Args as CommonArgs;
 use crate::github;
 use crate::github::RemoteRepo;
 
@@ -24,7 +25,7 @@ pub struct UnprotectedBranchArgs {
 }
 
 impl UnprotectedBranchArgs {
-    pub fn set_unprotected_branch(&self) -> Result<()> {
+    pub fn set_unprotected_branch(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -1,4 +1,5 @@
 use super::common;
+use crate::cli::Args as CommonArgs;
 use crate::git;
 use crate::user::User;
 
@@ -47,7 +48,7 @@ pub struct CheckoutArgs {
 }
 
 impl CheckoutArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/ci/export.rs
+++ b/src/commands/ci/export.rs
@@ -1,4 +1,5 @@
 use super::models::*;
+use crate::cli::Args as CommonArgs;
 use crate::commands::common;
 use crate::commands::models::ExistDirectory;
 use crate::commands::models::Script;
@@ -36,7 +37,7 @@ pub struct ExportArgs {
 }
 
 impl ExportArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user = common::user()?;
 
         let all_repos =

--- a/src/commands/ci/generate.rs
+++ b/src/commands/ci/generate.rs
@@ -1,4 +1,5 @@
 use super::models::*;
+use crate::cli::Args as CommonArgs;
 use crate::commands::common;
 use crate::commands::models::template::*;
 use crate::commands::models::ExistDirectory;
@@ -35,7 +36,7 @@ pub struct GenerateArgs {
 }
 
 impl GenerateArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user = common::user()?;
 
         let all_repos =

--- a/src/commands/ci/mod.rs
+++ b/src/commands/ci/mod.rs
@@ -2,6 +2,7 @@ pub mod export;
 pub mod generate;
 pub mod models;
 
+use crate::cli::Args as CommonArgs;
 use anyhow::Result;
 use clap::Parser;
 use export::*;
@@ -14,8 +15,8 @@ pub struct CiArgs {
 }
 /// Generate or export ci configuration
 impl CiArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -28,10 +29,10 @@ pub enum CiCommand {
 }
 
 impl CiCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            Self::Export(args) => args.run(),
-            Self::Generate(args) => args.run(),
+            Self::Export(args) => args.run(common_args),
+            Self::Generate(args) => args.run(common_args),
         }
     }
 }

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -1,4 +1,5 @@
 use super::common;
+use crate::cli::Args as CommonArgs;
 use crate::filter::Filter;
 use crate::git;
 use crate::path;
@@ -20,7 +21,7 @@ pub struct CleanArgs {
 }
 
 impl CleanArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let root = common::root()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
         let sub_dirs = common::read_dirs_for_org(&organisation, &root, self.regex.as_ref())?;

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -1,6 +1,7 @@
 use super::common;
 
 use crate::github::RemoteRepo;
+use crate::cli::Args as CommonArgs;
 use anyhow::{anyhow, Error, Result};
 
 use crate::convert::try_from_one;
@@ -30,7 +31,7 @@ pub struct CloneArgs {
 }
 
 impl CloneArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
         let use_https = match self.use_https {

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -1,4 +1,5 @@
 use super::common;
+use crate::cli::Args as CommonArgs;
 use crate::filter::Filter;
 use crate::git;
 use anyhow::Result;
@@ -36,7 +37,7 @@ pub struct CommitArgs {
 }
 
 impl CommitArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::create_branch::*;
 use super::create_discussion::*;
 use super::create_repo::*;
@@ -12,8 +13,8 @@ pub struct CreateArgs {
 }
 /// Create team, discussion, repo to an organisation or create a branch for repositories
 impl CreateArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -30,12 +31,12 @@ pub enum CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            Self::Discussion(args) => args.create_discusstion(),
-            Self::Team(args) => args.create_team(),
-            Self::Branch(args) => args.run(),
-            Self::Repo(args) => args.run(),
+            Self::Discussion(args) => args.create_discusstion(common_args),
+            Self::Team(args) => args.create_team(common_args),
+            Self::Branch(args) => args.run(common_args),
+            Self::Repo(args) => args.run(common_args),
         }
     }
 }

--- a/src/commands/create_branch.rs
+++ b/src/commands/create_branch.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use crate::commands::topic_helper;
 use crate::convert::try_from_one;
@@ -47,7 +48,7 @@ pub struct CreateBranchArgs {
 }
 
 impl CreateBranchArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/create_discussion.rs
+++ b/src/commands/create_discussion.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use crate::github;
 use crate::github::Unauthorized;
@@ -29,7 +30,7 @@ pub struct CreateDiscussionArgs {
 }
 
 impl CreateDiscussionArgs {
-    pub fn create_discusstion(&self) -> Result<()> {
+    pub fn create_discusstion(&self, _common_args: &CommonArgs) -> Result<()> {
         let token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/create_repo.rs
+++ b/src/commands/create_repo.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use crate::github::create_org_repo;
 use crate::user::User;
@@ -43,7 +44,7 @@ pub struct CreateRepoArgs {
 }
 
 impl CreateRepoArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         log::debug!("Create Repo {:?}", self);
 
         let root = common::root()?;

--- a/src/commands/create_team.rs
+++ b/src/commands/create_team.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use crate::github;
 use crate::github::{CreateTeamResponse, Unauthorized};
@@ -29,7 +30,7 @@ pub struct CreateTeamArgs {
 }
 
 impl CreateTeamArgs {
-    pub fn create_team(&self) -> Result<()> {
+    pub fn create_team(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
 
         match create_team(self, &user_token) {

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use crate::filter::Filter;
 use crate::git;
@@ -24,7 +25,7 @@ pub struct FetchArgs {
 }
 
 impl FetchArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user = common::user()?;
         let root = common::root()?;
         let organisation = common::organisation(self.organisation.as_deref())?;

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::hook_create::*;
 use super::hook_delete::*;
 use anyhow::Result;
@@ -10,8 +11,8 @@ pub struct HookArgs {
 }
 /// Create, delete hooks for all repositories that match a pattern
 impl HookArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -24,10 +25,10 @@ pub enum HookCommand {
 }
 
 impl HookCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            Self::Create(args) => args.run(),
-            Self::Delete(args) => args.run(),
+            Self::Create(args) => args.run(common_args),
+            Self::Delete(args) => args.run(common_args),
         }
     }
 }

--- a/src/commands/hook_create.rs
+++ b/src/commands/hook_create.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use super::models::Script;
 use crate::github;
@@ -75,7 +76,7 @@ impl Method {
 }
 
 impl CreateArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/hook_delete.rs
+++ b/src/commands/hook_delete.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use crate::github;
 
@@ -22,7 +23,7 @@ pub struct DeleteArgs {
 }
 
 impl DeleteArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/init_config.rs
+++ b/src/commands/init_config.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::models::RootDirectory;
 use crate::config::Config;
 use crate::github;
@@ -24,7 +25,7 @@ pub struct InitArgs {
 }
 
 impl InitArgs {
-    pub fn save_config(&self) -> anyhow::Result<()> {
+    pub fn save_config(&self, _common_args: &CommonArgs) -> anyhow::Result<()> {
         let user = match User::new(self.token.clone()) {
                 Ok(user) => { user },
                 Err(e) => match e.downcast_ref::<github::Unauthorized>() {

--- a/src/commands/invite.rs
+++ b/src/commands/invite.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::invite_users::*;
 use anyhow::Result;
 use clap::Parser;
@@ -9,8 +10,8 @@ pub struct InviteArgs {
 }
 /// Invite users to an organisation by emails
 impl InviteArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -21,9 +22,9 @@ pub enum InviteCommand {
 }
 
 impl InviteCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            Self::Users(args) => args.run(),
+            Self::Users(args) => args.run(common_args),
         }
     }
 }

--- a/src/commands/invite_users.rs
+++ b/src/commands/invite_users.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use crate::github;
 use std::fmt;
@@ -82,7 +83,7 @@ impl fmt::Display for Role {
 }
 
 impl InviteUsersArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/make.rs
+++ b/src/commands/make.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use super::common;
 
+use crate::cli::Args as CommonArgs;
 use crate::filter::Filter;
 use crate::github;
 use anyhow::Result;
@@ -53,7 +54,7 @@ impl Visibility {
 }
 
 impl MakeArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use crate::filter::Filter;
 use crate::git;
@@ -26,7 +27,7 @@ pub struct MergeArgs {
 }
 
 impl MergeArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let root = common::root()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -6,6 +6,7 @@ use prettytable::{cell, format, row, Cell, Row, Table};
 use crate::git;
 use anyhow::{Context, Error, Result};
 
+use crate::cli::Args as CommonArgs;
 use crate::filter::Filter;
 use crate::git::push;
 use crate::git::GitCredential;
@@ -40,7 +41,7 @@ pub struct PushArgs {
 }
 
 impl PushArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user = common::user()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::remove_repos::*;
 use super::remove_users::*;
 use anyhow::Result;
@@ -10,8 +11,8 @@ pub struct RemoveArgs {
 }
 /// Remove users, repos from an organisation/a team.
 impl RemoveArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -24,10 +25,10 @@ pub enum RemoveCommand {
 }
 
 impl RemoveCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            Self::Users(args) => args.run(),
-            Self::Repos(args) => args.run(),
+            Self::Users(args) => args.run(common_args),
+            Self::Repos(args) => args.run(common_args),
         }
     }
 }

--- a/src/commands/remove_repos.rs
+++ b/src/commands/remove_repos.rs
@@ -1,5 +1,6 @@
 use super::common;
 
+use crate::cli::Args as CommonArgs;
 use crate::filter::Filter;
 use crate::github;
 use crate::github::RemoteRepo;
@@ -19,7 +20,7 @@ pub struct RemoveReposArgs {
 }
 
 impl RemoveReposArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/remove_users.rs
+++ b/src/commands/remove_users.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use crate::github;
 
@@ -24,14 +25,14 @@ pub struct RemoveUsersArgs {
 }
 
 impl RemoveUsersArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match &self.team_slug {
-            Some(name) => self.remove_users_from_team(name),
-            None => self.remove_users_from_org(),
+            Some(name) => self.remove_users_from_team(name, common_args),
+            None => self.remove_users_from_org(common_args),
         }
     }
 
-    fn remove_users_from_org(&self) -> Result<()> {
+    fn remove_users_from_org(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 
@@ -44,7 +45,7 @@ impl RemoveUsersArgs {
         Ok(())
     }
 
-    fn remove_users_from_team(&self, team_name: &str) -> Result<()> {
+    fn remove_users_from_team(&self, team_name: &str, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -1,5 +1,6 @@
 use super::common;
 
+use crate::cli::Args as CommonArgs;
 use crate::filter::Filter;
 use crate::github;
 use anyhow::Result;
@@ -26,7 +27,7 @@ pub struct RenameArgs {
 }
 
 impl RenameArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -2,6 +2,7 @@ use super::set_default_organisation::*;
 use super::set_info::*;
 use super::set_secret::*;
 use super::set_team_permission::*;
+use crate::cli::Args as CommonArgs;
 use anyhow::Result;
 use clap::Parser;
 
@@ -12,8 +13,8 @@ pub struct SetArgs {
 }
 /// Set information, secret for repositories or permission for a team
 impl SetArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -30,12 +31,12 @@ pub enum SetCommand {
 }
 
 impl SetCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            Self::Info(args) => args.run(),
-            Self::Organisation(args) => args.run(),
-            Self::Permission(args) => args.set_permission(),
-            Self::Secret(args) => args.run(),
+            Self::Info(args) => args.run(common_args),
+            Self::Organisation(args) => args.run(common_args),
+            Self::Permission(args) => args.set_permission(common_args),
+            Self::Secret(args) => args.run(common_args),
         }
     }
 }

--- a/src/commands/set_default_organisation.rs
+++ b/src/commands/set_default_organisation.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use crate::config::Config;
 use clap::Parser;
 
@@ -10,7 +11,7 @@ pub struct SetOrganisationArgs {
 }
 
 impl SetOrganisationArgs {
-    pub fn run(&self) -> anyhow::Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> anyhow::Result<()> {
         let mut config = Config::from_file()?;
         config.default_org = Some(self.organisation.clone());
         config.save_config()

--- a/src/commands/set_info.rs
+++ b/src/commands/set_info.rs
@@ -1,6 +1,7 @@
 use super::common;
 use super::models::Script;
 use crate::github;
+use crate::cli::Args as CommonArgs;
 
 use crate::github::RemoteRepo;
 use anyhow::{anyhow, Result};
@@ -40,7 +41,7 @@ pub struct InfoArgs {
 }
 
 impl InfoArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/set_secret.rs
+++ b/src/commands/set_secret.rs
@@ -1,6 +1,7 @@
 use std::convert::TryFrom;
 
 use super::common;
+use crate::cli::Args as CommonArgs;
 use crate::filter::Filter;
 use crate::github;
 use crate::github::RemoteRepo;
@@ -28,7 +29,7 @@ pub struct SecretArgs {
 }
 
 impl SecretArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/set_team_permission.rs
+++ b/src/commands/set_team_permission.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use crate::github;
 
@@ -29,7 +30,7 @@ pub struct SetTeamPermissionArgs {
 }
 
 impl SetTeamPermissionArgs {
-    pub fn set_permission(&self) -> Result<()> {
+    pub fn set_permission(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -3,6 +3,7 @@ use super::show_repos::*;
 use super::show_users::*;
 use anyhow::Result;
 use clap::Parser;
+use crate::cli::Args as CommonArgs;
 
 #[derive(Debug, Parser)]
 pub struct ShowArgs {
@@ -11,8 +12,8 @@ pub struct ShowArgs {
 }
 /// Show config, list of repositories or users
 impl ShowArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -28,11 +29,11 @@ pub enum ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            Self::Config => show_config(),
-            Self::Repos(args) => args.show(),
-            Self::Users(args) => args.run(),
+            Self::Config => show_config(common_args),
+            Self::Repos(args) => args.show(common_args),
+            Self::Users(args) => args.run(common_args),
         }
     }
 }

--- a/src/commands/show_config.rs
+++ b/src/commands/show_config.rs
@@ -1,7 +1,8 @@
 use super::common;
+use crate::cli::Args as CommonArgs;
 use crate::config::Config;
 
-pub fn show_config() -> anyhow::Result<()> {
+pub fn show_config(_common_args: &CommonArgs) -> anyhow::Result<()> {
     let user = common::user()?;
     let root = Config::root()?;
     let organisation = match common::organisation(None) {

--- a/src/commands/show_repos.rs
+++ b/src/commands/show_repos.rs
@@ -1,6 +1,7 @@
 use super::common;
 
 use crate::filter::Filter;
+use crate::cli::Args as CommonArgs;
 use clap::Parser;
 
 #[derive(Debug, Parser)]
@@ -17,7 +18,7 @@ pub struct ShowReposArgs {
 }
 
 impl ShowReposArgs {
-    pub fn show(&self) -> anyhow::Result<()> {
+    pub fn show(&self, _common_args: &CommonArgs) -> anyhow::Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/show_users.rs
+++ b/src/commands/show_users.rs
@@ -1,4 +1,5 @@
 use super::common;
+use crate::cli::Args as CommonArgs;
 use crate::github;
 use anyhow::Result;
 use clap::Parser;
@@ -22,7 +23,7 @@ pub struct ShowUsersArgs {
 }
 
 impl ShowUsersArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/template/apply.rs
+++ b/src/commands/template/apply.rs
@@ -1,4 +1,5 @@
 use super::patch_file::*;
+use crate::cli::Args as CommonArgs;
 use crate::commands::common;
 use crate::commands::models::template::*;
 use crate::commands::models::ExistDirectory;
@@ -40,7 +41,7 @@ pub struct ApplyArgs {
 }
 
 impl ApplyArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         if self.finish && self.abort {
             println!("You cannot provide both \"--continue\" and \"--abort\" at the same time");
             return Ok(());

--- a/src/commands/template/generate.rs
+++ b/src/commands/template/generate.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use crate::commands::common;
 use crate::commands::models::template::*;
 use crate::commands::models::ExistDirectory;
@@ -27,7 +28,7 @@ pub struct GenerateArgs {
 }
 
 impl GenerateArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let template_dir = &self.template.path;
         let target_dir = Path::new(&self.dir).to_path_buf();
         create_dir_all(&target_dir).context("Cannot create target directory")?;

--- a/src/commands/template/mod.rs
+++ b/src/commands/template/mod.rs
@@ -2,6 +2,7 @@ pub mod apply;
 pub mod generate;
 pub mod patch_file;
 
+use crate::cli::Args as CommonArgs;
 use anyhow::Result;
 use apply::*;
 use generate::*;
@@ -15,8 +16,8 @@ pub struct TemplateArgs {
 }
 /// Apply changes or generate new template
 impl TemplateArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -29,10 +30,10 @@ pub enum TemplateCommand {
 }
 
 impl TemplateCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            Self::Apply(args) => args.run(),
-            Self::Generate(args) => args.run(),
+            Self::Apply(args) => args.run(common_args),
+            Self::Generate(args) => args.run(common_args),
         }
     }
 }

--- a/src/commands/topic.rs
+++ b/src/commands/topic.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::topic_add::*;
 use super::topic_apply::*;
 use super::topic_get::*;
@@ -12,8 +13,8 @@ pub struct TopicArgs {
 }
 /// Add, get, set or apply a script by topic
 impl TopicArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -30,12 +31,12 @@ pub enum TopicCommand {
 }
 
 impl TopicCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            Self::Get(args) => args.run(),
-            Self::Set(args) => args.run(),
-            Self::Add(args) => args.run(),
-            Self::Apply(args) => args.run(),
+            Self::Get(args) => args.run(common_args),
+            Self::Set(args) => args.run(common_args),
+            Self::Add(args) => args.run(common_args),
+            Self::Apply(args) => args.run(common_args),
         }
     }
 }

--- a/src/commands/topic_add.rs
+++ b/src/commands/topic_add.rs
@@ -1,3 +1,4 @@
+use crate::cli::Args as CommonArgs;
 use super::common;
 use crate::filter::Filter;
 use crate::github;
@@ -21,7 +22,7 @@ pub struct TopicAddArgs {
 }
 
 impl TopicAddArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/topic_apply.rs
+++ b/src/commands/topic_apply.rs
@@ -1,6 +1,7 @@
 use super::common;
 use super::models::Script;
 use super::topic_helper;
+use crate::cli::Args as CommonArgs;
 use crate::convert::try_from_one;
 use crate::filter::Filter;
 use crate::github::RemoteRepoWithTopics;
@@ -33,7 +34,7 @@ pub struct TopicApplyArgs {
 }
 
 impl TopicApplyArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         println!("Topic apply {:?}", self);
 
         let script_path = self

--- a/src/commands/topic_get.rs
+++ b/src/commands/topic_get.rs
@@ -3,6 +3,7 @@ use crate::filter::Filter;
 use crate::github;
 use anyhow::Result;
 use clap::Parser;
+use crate::cli::Args as CommonArgs;
 
 #[derive(Debug, Parser)]
 /// Get topics for all repositories that match a regex
@@ -18,7 +19,7 @@ pub struct TopicGetArgs {
 }
 
 impl TopicGetArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/topic_set.rs
+++ b/src/commands/topic_set.rs
@@ -1,4 +1,5 @@
 use super::common;
+use crate::cli::Args as CommonArgs;
 use crate::filter::Filter;
 use crate::github;
 use anyhow::Result;
@@ -21,7 +22,7 @@ pub struct TopicSetArgs {
 }
 
 impl TopicSetArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -1,4 +1,5 @@
 use super::common;
+use crate::cli::Args as CommonArgs;
 use crate::filter::Filter;
 use crate::github;
 use anyhow::Result;
@@ -24,7 +25,7 @@ pub struct TransferArgs {
 }
 
 impl TransferArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/commands/workflow.rs
+++ b/src/commands/workflow.rs
@@ -1,4 +1,5 @@
 use super::workflow_run::*;
+use crate::cli::Args as CommonArgs;
 use anyhow::Result;
 use clap::Parser;
 
@@ -9,8 +10,8 @@ pub struct WorkflowArgs {
 }
 /// Run a workflow
 impl WorkflowArgs {
-    pub fn run(&self) -> Result<()> {
-        self.command.run()
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
+        self.command.run(common_args)
     }
 }
 
@@ -21,9 +22,9 @@ pub enum WorkflowCommand {
 }
 
 impl WorkflowCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, common_args: &CommonArgs) -> Result<()> {
         match self {
-            Self::Run(args) => args.run(),
+            Self::Run(args) => args.run(common_args),
         }
     }
 }

--- a/src/commands/workflow_run.rs
+++ b/src/commands/workflow_run.rs
@@ -1,5 +1,6 @@
 use super::common;
 
+use crate::cli::Args as CommonArgs;
 use crate::filter::Filter;
 use crate::github;
 use crate::github::RemoteRepo;
@@ -32,7 +33,7 @@ pub struct WorkflowRunArgs {
 }
 
 impl WorkflowRunArgs {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self, _common_args: &CommonArgs) -> Result<()> {
         let user_token = common::user_token()?;
         let organisation = common::organisation(self.organisation.as_deref())?;
 

--- a/src/git/pull.rs
+++ b/src/git/pull.rs
@@ -5,9 +5,10 @@ use super::models::GitCredential;
 use super::rebase;
 use anyhow::Result;
 use git2::Repository;
+use serde::Serialize;
 use std::str;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum PullStatus {
     Normal,
     Nothing,

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -1,6 +1,7 @@
 use git2::{Error, Repository, Status, StatusOptions};
+use serde::Serialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GitStatus {
     pub added: Vec<String>,
     pub new: Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,35 +21,35 @@ fn main() -> Result<()> {
         .filter(Some("gut"), log::LevelFilter::Debug)
         .init();
 
-    let args = Args::parse();
-    log::debug!("Arguments: {:?}", args);
+    let common_args = Args::parse();
+    log::debug!("Arguments: {:?}", common_args);
 
-    match args.command {
-        Commands::Add(args) => args.run(),
-        Commands::Apply(args) => args.run(),
-        Commands::Branch(args) => args.run(),
-        Commands::Checkout(args) => args.run(),
-        Commands::Ci(args) => args.run(),
-        Commands::Clone(args) => args.run(),
-        Commands::Clean(args) => args.run(),
-        Commands::Commit(args) => args.run(),
-        Commands::Create(args) => args.run(),
-        Commands::Fetch(args) => args.run(),
-        Commands::Hook(args) => args.run(),
-        Commands::Init(args) => args.save_config(),
-        Commands::Invite(args) => args.run(),
-        Commands::Merge(args) => args.run(),
-        Commands::Make(args) => args.run(),
-        Commands::Pull(args) => args.run(),
-        Commands::Push(args) => args.run(),
-        Commands::Remove(args) => args.run(),
-        Commands::Rename(args) => args.run(),
-        Commands::Set(args) => args.run(),
-        Commands::Show(args) => args.run(),
-        Commands::Status(args) => args.run(),
-        Commands::Template(args) => args.run(),
-        Commands::Topic(args) => args.run(),
-        Commands::Transfer(args) => args.run(),
-        Commands::Workflow(args) => args.run(),
+    match &common_args.command {
+        Commands::Add(args) => args.run(&common_args),
+        Commands::Apply(args) => args.run(&common_args),
+        Commands::Branch(args) => args.run(&common_args),
+        Commands::Checkout(args) => args.run(&common_args),
+        Commands::Ci(args) => args.run(&common_args),
+        Commands::Clone(args) => args.run(&common_args),
+        Commands::Clean(args) => args.run(&common_args),
+        Commands::Commit(args) => args.run(&common_args),
+        Commands::Create(args) => args.run(&common_args),
+        Commands::Fetch(args) => args.run(&common_args),
+        Commands::Hook(args) => args.run(&common_args),
+        Commands::Init(args) => args.save_config(&common_args),
+        Commands::Invite(args) => args.run(&common_args),
+        Commands::Merge(args) => args.run(&common_args),
+        Commands::Make(args) => args.run(&common_args),
+        Commands::Pull(args) => args.run(&common_args),
+        Commands::Push(args) => args.run(&common_args),
+        Commands::Remove(args) => args.run(&common_args),
+        Commands::Rename(args) => args.run(&common_args),
+        Commands::Set(args) => args.run(&common_args),
+        Commands::Show(args) => args.run(&common_args),
+        Commands::Status(args) => args.run(&common_args),
+        Commands::Template(args) => args.run(&common_args),
+        Commands::Topic(args) => args.run(&common_args),
+        Commands::Transfer(args) => args.run(&common_args),
+        Commands::Workflow(args) => args.run(&common_args),
     }
 }


### PR DESCRIPTION
Currently the argument handler supports "--format json" and "--format table" (which also is the default when not given at all), and it passes down this information to every method that is run. Most of them do not make use of it yet, only "pull" and "status".

The way the argument had to be passed down in every handler as an argument to the function seemed a bit excessive. There is almost certainly a better way of doing it.