### PR TITLE
Add health check warnings for core.precomposeUnicode on macOS

### DIFF
--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -7,6 +7,7 @@ use crate::convert::try_from_one;
 use crate::filter::Filter;
 use crate::git::Clonable;
 use crate::git::models::GitRepo;
+use crate::health;
 use crate::user::User;
 use clap::Parser;
 use colored::*;
@@ -30,6 +31,8 @@ pub struct CloneArgs {
 
 impl CloneArgs {
     pub fn run(&self) -> Result<()> {
+        let warnings = health::check_git_config();
+        
         let user = common::user()?;
         let owner = common::owner(self.owner.as_deref())?;
         let use_https = match self.use_https {
@@ -56,7 +59,8 @@ impl CloneArgs {
         );
 
         summarize(&statuses);
-
+        
+        health::print_warnings(&warnings);
         Ok(())
     }
 }

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -1,6 +1,7 @@
 use super::common::{self, OrgResult};
 use crate::filter::Filter;
 use crate::git;
+use crate::health;
 use crate::path;
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -32,12 +33,17 @@ pub struct CommitArgs {
 
 impl CommitArgs {
     pub fn run(&self) -> Result<()> {
-        common::run_for_owners(
+        let warnings = health::check_git_config();
+        
+        let result = common::run_for_owners(
             self.all_owners,
             self.owner.as_deref(),
             |owner| self.run_for_owner(owner),
             "Committed",
-        )
+        );
+        
+        health::print_warnings(&warnings);
+        result
     }
 
     fn run_for_owner(&self, owner: &str) -> Result<OrgResult> {

--- a/src/commands/init_config.rs
+++ b/src/commands/init_config.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::github;
+use crate::health;
 use crate::user::User;
 use clap::Parser;
 use std::path::PathBuf;
@@ -52,6 +53,8 @@ pub struct InitArgs {
 
 impl InitArgs {
     pub fn save_config(&self) -> anyhow::Result<()> {
+        let warnings = health::check_git_config();
+        
         let user = match User::new(self.token.clone()) {
             Ok(user) => user,
             Err(e) => match e.downcast_ref::<github::Unauthorized>() {
@@ -67,6 +70,9 @@ impl InitArgs {
             self.owner.clone(),
             self.use_https,
         );
-        config.save_config()
+        config.save_config()?;
+        
+        health::print_warnings(&warnings);
+        Ok(())
     }
 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,81 @@
+use colored::*;
+use std::process::Command;
+
+/// Health check warnings that should be displayed to the user
+#[derive(Debug, Clone)]
+pub struct HealthWarning {
+    pub title: String,
+    pub message: String,
+    pub suggestion: Option<String>,
+}
+
+impl HealthWarning {
+    pub fn print(&self) {
+        eprintln!("\n{} {}", "⚠️  Warning:".yellow().bold(), self.title.yellow());
+        eprintln!("   {}", self.message);
+        if let Some(suggestion) = &self.suggestion {
+            eprintln!("   {}", suggestion.bright_black());
+        }
+    }
+}
+
+/// Run health checks and return any warnings
+pub fn check_git_config() -> Vec<HealthWarning> {
+    let mut warnings = Vec::new();
+
+    // Check core.precomposeUnicode on macOS
+    if cfg!(target_os = "macos") {
+        if let Some(warning) = check_precompose_unicode() {
+            warnings.push(warning);
+        }
+    }
+
+    warnings
+}
+
+/// Check if core.precomposeUnicode is properly set on macOS
+fn check_precompose_unicode() -> Option<HealthWarning> {
+    let output = Command::new("git")
+        .args(&["config", "--get", "core.precomposeUnicode"])
+        .output()
+        .ok()?;
+
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_lowercase();
+
+    if value != "true" {
+        return Some(HealthWarning {
+            title: "core.precomposeUnicode not set".to_string(),
+            message: "Git setting 'core.precomposeUnicode' is not enabled.".to_string(),
+            suggestion: Some(
+                "Run: git config --global core.precomposeUnicode true\n   \
+                This prevents Unicode normalization issues with filenames on macOS."
+                    .to_string(),
+            ),
+        });
+    }
+
+    None
+}
+
+/// Print all health warnings at the end of command execution
+pub fn print_warnings(warnings: &[HealthWarning]) {
+    if !warnings.is_empty() {
+        eprintln!(); // Empty line before warnings
+        for warning in warnings {
+            warning.print();
+        }
+    }
+}
+
+// Additional health checks that could be implemented:
+//
+// 1. Check for LFS installation when repo uses Git LFS
+// 2. Check for sufficient disk space
+// 3. Check Git version (minimum required version)
+// 4. Check for proper SSH key configuration
+// 5. Check for .gitignore patterns that might cause issues
+// 6. Check for very long filenames (macOS has limits)
+// 7. Check for case sensitivity issues (macOS is case-insensitive by default)
+// 8. Check for proper line ending configuration (core.autocrlf)
+// 9. Check for Git credential helper configuration
+// 10. Check for NFD/NFC normalization conflicts in existing repos

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod convert;
 mod filter;
 mod git;
 mod github;
+mod health;
 mod path;
 mod toml;
 mod user;


### PR DESCRIPTION
Implements prevention strategy from #202 by adding health checks to warn
macOS users if core.precomposeUnicode is not properly configured.

The health check runs in init, clone, pull, and commit commands and
displays warnings at the end without blocking execution.

Closes #202
