### PR TITLE
Make --organisation optional

### DIFF
--- a/src/commands/add_repos.rs
+++ b/src/commands/add_repos.rs
@@ -15,7 +15,7 @@ use rayon::prelude::*;
 pub struct AddRepoArgs {
     #[arg(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    pub organisation: Option<String>,
     #[arg(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -31,10 +31,10 @@ pub struct AddRepoArgs {
 impl AddRepoArgs {
     pub fn run(&self) -> Result<()> {
         let user = common::user()?;
-        let organisation = &self.organisation;
+        let organisation = common::owner(self.organisation.as_deref())?;
 
         let filtered_repos =
-            common::query_and_filter_repositories(organisation, self.regex.as_ref(), &user.token)?;
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user.token)?;
 
         if filtered_repos.is_empty() {
             println!(

--- a/src/commands/create_team.rs
+++ b/src/commands/create_team.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 pub struct CreateTeamArgs {
     #[arg(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    pub organisation: Option<String>,
     #[arg(long, short)]
     /// Team name
     pub team_name: String,
@@ -31,8 +31,9 @@ pub struct CreateTeamArgs {
 impl CreateTeamArgs {
     pub fn create_team(&self) -> Result<()> {
         let user_token = common::user_token()?;
+        let organisation = common::owner(self.organisation.as_deref())?;
 
-        match create_team(self, &user_token) {
+        match create_team(self, &organisation, &user_token) {
             Ok(r) => println!(
                 "You created a team named: {} successfully with id: {} and link : {}",
                 self.team_name, r.id, r.html_url
@@ -48,12 +49,16 @@ impl CreateTeamArgs {
     }
 }
 
-fn create_team(args: &CreateTeamArgs, token: &str) -> Result<CreateTeamResponse> {
+fn create_team(
+    args: &CreateTeamArgs,
+    organisation: &str,
+    token: &str,
+) -> Result<CreateTeamResponse> {
     let des = args.description.as_deref().unwrap_or("");
     let members: Vec<String> = args.members.iter().map(|s| s.to_string()).collect();
 
     match github::create_team(
-        &args.organisation,
+        organisation,
         &args.team_name,
         des,
         members,

--- a/src/commands/set_team_permission.rs
+++ b/src/commands/set_team_permission.rs
@@ -18,7 +18,7 @@ use rayon::prelude::*;
 pub struct SetTeamPermissionArgs {
     #[arg(long, short)]
     /// Target organisation name
-    pub organisation: String,
+    pub organisation: Option<String>,
     #[arg(long, short)]
     /// Optional regex to filter repositories
     pub regex: Option<Filter>,
@@ -42,14 +42,14 @@ fn parse_permission(src: &str) -> Result<String> {
 impl SetTeamPermissionArgs {
     pub fn set_permission(&self) -> Result<()> {
         let user_token = common::user_token()?;
-        let organisation = &self.organisation;
+        let organisation = common::owner(self.organisation.as_deref())?;
 
         let filtered_repos =
-            common::query_and_filter_repositories(organisation, self.regex.as_ref(), &user_token)?;
+            common::query_and_filter_repositories(&organisation, self.regex.as_ref(), &user_token)?;
 
         filtered_repos.par_iter().for_each(|repo| {
             let result = github::set_team_permission(
-                organisation,
+                &organisation,
                 &self.team_slug,
                 &repo.owner,
                 &repo.name,

--- a/src/commands/show_repo.rs
+++ b/src/commands/show_repo.rs
@@ -19,17 +19,17 @@ pub struct ShowRepoArgs {
     /// The repository name
     pub repo_name: String,
     #[arg(long, short)]
-    /// Target organisation name
-    pub organisation: Option<String>,
+    /// Target owner (organisation or user)
+    pub owner: Option<String>,
 }
 
 impl ShowRepoArgs {
     pub fn run(&self) -> Result<()> {
         let user_token = common::user_token()?;
-        let organisation = common::owner(self.organisation.as_deref())?;
+        let owner = common::owner(self.owner.as_deref())?;
         let repo_name = &self.repo_name;
 
-        match github::get_repo_teams(&organisation, repo_name, &user_token) {
+        match github::get_repo_teams(&owner, repo_name, &user_token) {
             Ok(teams) => {
                 print_teams(&teams);
             }
@@ -38,12 +38,12 @@ impl ShowRepoArgs {
                     && unsuccessful.0 == StatusCode::NOT_FOUND
                 {
                     println!(
-                        "Could not find repository '{}/{}'. Check the name and organisation.",
-                        organisation, repo_name
+                        "Could not find repository '{}/{}'. Check the name and owner.",
+                        owner, repo_name
                     );
-                    if self.organisation.is_none() {
+                    if self.owner.is_none() {
                         println!(
-                            "If this repository belongs to a different organisation, use: gut show repository {} -o <organisation>",
+                            "If this repository belongs to a different owner, use: gut show repository {} -o <owner>",
                             repo_name
                         );
                     }
@@ -65,11 +65,11 @@ impl ShowRepoArgs {
         spinner.enable_steady_tick(Duration::from_millis(100));
 
         let collaborators_result =
-            github::get_repo_collaborators(&organisation, repo_name, &user_token, None);
+            github::get_repo_collaborators(&owner, repo_name, &user_token, None);
         let direct_result =
-            github::get_repo_collaborators(&organisation, repo_name, &user_token, Some("direct"));
+            github::get_repo_collaborators(&owner, repo_name, &user_token, Some("direct"));
         let outside_result =
-            github::get_repo_collaborators(&organisation, repo_name, &user_token, Some("outside"));
+            github::get_repo_collaborators(&owner, repo_name, &user_token, Some("outside"));
 
         spinner.finish_and_clear();
 

--- a/src/commands/show_teams.rs
+++ b/src/commands/show_teams.rs
@@ -1,10 +1,8 @@
 use super::common;
 use crate::github;
-use crate::github::models::Unsuccessful;
 use anyhow::Result;
 use clap::Parser;
 use prettytable::{Cell, Row, Table, format, row};
-use reqwest::StatusCode;
 use std::collections::HashMap;
 
 #[derive(Debug, Parser)]
@@ -36,16 +34,12 @@ impl ShowTeamsArgs {
                 }
             }
             Err(e) => {
-                if let Some(unsuccessful) = e.downcast_ref::<Unsuccessful>()
-                    && unsuccessful.0 == StatusCode::NOT_FOUND
-                {
-                    println!("Could not find teams for '{}'.", organisation);
-                    println!("Note: Teams only exist in organisations, not personal accounts.");
-                    if self.organisation.is_none() {
-                        println!(
-                            "If you meant a different organisation, use: gut show teams -o <organisation>"
-                        );
-                    }
+                if common::handle_org_not_found(
+                    &e,
+                    &format!("Could not find teams for '{}'.", organisation),
+                    "gut show teams -o <organisation>",
+                    self.organisation.is_some(),
+                ) {
                     return Ok(());
                 }
                 println!("Show teams failed: {:?}", e);


### PR DESCRIPTION
Fix #213 

The newer commands (show teams, show team, show repository) already used an optional -o flag that falls back to config.default_owner. This makes all 9 older commands consistent with that pattern: show members, show access, add repos, add users, remove users, create discussion, create team, invite users, set permission.

- Add common::handle_org_not_found() helper for org-only commands to detect 404 errors and print guidance about organisations vs personal accounts, with a command hint when the owner was defaulted
- Refactor show_teams, show_team to use the shared helper instead of inline 404 handling
- Rename -o/--organisation to -o/--owner in show access and show repo since those commands work with both organisations and personal accounts
- Short-circuit team_slug_to_ids in invite_users when no teams are specified to avoid unnecessary API call
- Consolidate org resolution in add_users and remove_users to resolve once at the top of run() instead of per-branch