### PR TITLE
Add git lfs support to `clone` and `pull`

### DIFF
--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -128,17 +128,18 @@ impl Status {
     }
 
     fn has_error(&self) -> bool {
-        self.result.is_err()
+        self.result.is_err() || matches!(self.lfs_status, LfsPullStatus::Failed(_))
     }
 
     fn to_error_row(&self) -> Row {
-        let e = if let Err(e) = &self.result {
-            e
+        let msg = if let Err(e) = &self.result {
+            format!("{:?}", e)
+        } else if let LfsPullStatus::Failed(e) = &self.lfs_status {
+            format!("LFS pull failed: {}", e)
         } else {
             panic!("This should have an error here");
         };
 
-        let msg = format!("{:?}", e);
         let lines = common::sub_strings(msg.as_str(), 80);
         let lines = lines.join("\n");
         row!(cell!(b -> &self.repo.name), cell!(Fr -> lines.as_str()))

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -296,19 +296,22 @@ impl Status {
     }
 
     fn has_error(&self) -> bool {
-        self.status.is_err() || matches!(self.stash_status, StashStatus::Failed(_))
+        self.status.is_err()
+            || matches!(self.stash_status, StashStatus::Failed(_))
+            || matches!(self.lfs_status, LfsPullStatus::Failed(_))
     }
 
     fn to_error_row(&self) -> Row {
-        let e = if let StashStatus::Failed(e1) = &self.stash_status {
-            e1
-        } else if let Err(e2) = &self.status {
-            e2
+        let msg = if let StashStatus::Failed(e) = &self.stash_status {
+            format!("{:?}", e)
+        } else if let Err(e) = &self.status {
+            format!("{:?}", e)
+        } else if let LfsPullStatus::Failed(e) = &self.lfs_status {
+            format!("LFS pull failed: {}", e)
         } else {
             panic!("This should have an error here");
         };
 
-        let msg = format!("{:?}", e);
         let lines = common::sub_strings(msg.as_str(), 80);
         let lines = lines.join("\n");
         row!(cell!(b -> &self.repo), cell!(Fr -> lines.as_str()))

--- a/src/git/lfs.rs
+++ b/src/git/lfs.rs
@@ -1,0 +1,47 @@
+use crate::system_health;
+use serde::Serialize;
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Clone, Serialize)]
+pub enum LfsPullStatus {
+    Success,
+    Failed(String),
+    NotNeeded,
+    LfsNotInstalled,
+}
+
+/// Check if a repository uses Git LFS by looking for `filter=lfs` in `.gitattributes`.
+pub fn repo_uses_lfs(repo_path: &Path) -> bool {
+    let gitattributes = repo_path.join(".gitattributes");
+    if let Ok(contents) = std::fs::read_to_string(gitattributes) {
+        contents.contains("filter=lfs")
+    } else {
+        false
+    }
+}
+
+/// Run `git lfs pull` in the given repository directory.
+/// Returns the status of the operation.
+pub fn lfs_pull(repo_path: &Path) -> LfsPullStatus {
+    if !repo_uses_lfs(repo_path) {
+        return LfsPullStatus::NotNeeded;
+    }
+
+    if !system_health::is_git_lfs_installed() {
+        return LfsPullStatus::LfsNotInstalled;
+    }
+
+    match Command::new("git")
+        .args(["lfs", "pull"])
+        .current_dir(repo_path)
+        .output()
+    {
+        Ok(output) if output.status.success() => LfsPullStatus::Success,
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            LfsPullStatus::Failed(stderr)
+        }
+        Err(e) => LfsPullStatus::Failed(e.to_string()),
+    }
+}

--- a/src/git/lfs.rs
+++ b/src/git/lfs.rs
@@ -15,7 +15,10 @@ pub enum LfsPullStatus {
 pub fn repo_uses_lfs(repo_path: &Path) -> bool {
     let gitattributes = repo_path.join(".gitattributes");
     if let Ok(contents) = std::fs::read_to_string(gitattributes) {
-        contents.contains("filter=lfs")
+        contents.lines().any(|line| {
+            let line = line.trim();
+            !line.starts_with('#') && line.contains("filter=lfs")
+        })
     } else {
         false
     }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -4,6 +4,7 @@ pub mod commit;
 pub mod common;
 pub mod diff;
 pub mod fetch;
+pub mod lfs;
 pub mod merge;
 pub mod models;
 pub mod open;

--- a/src/system_health.rs
+++ b/src/system_health.rs
@@ -1,5 +1,6 @@
 use colored::*;
 use std::process::Command;
+use std::sync::LazyLock;
 
 /// Types of health warnings for type-safe matching
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,13 +85,17 @@ fn get_git_config(key: &str) -> Option<String> {
     if value.is_empty() { None } else { Some(value) }
 }
 
-/// Check if Git LFS is installed
-pub fn is_git_lfs_installed() -> bool {
+static GIT_LFS_INSTALLED: LazyLock<bool> = LazyLock::new(|| {
     Command::new("git")
         .args(["lfs", "version"])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+});
+
+/// Check if Git LFS is installed (cached after first call).
+pub fn is_git_lfs_installed() -> bool {
+    *GIT_LFS_INSTALLED
 }
 
 /// Parse a Git version string into (major, minor, patch) tuple.

--- a/src/system_health.rs
+++ b/src/system_health.rs
@@ -85,7 +85,7 @@ fn get_git_config(key: &str) -> Option<String> {
 }
 
 /// Check if Git LFS is installed
-fn is_git_lfs_installed() -> bool {
+pub fn is_git_lfs_installed() -> bool {
     Command::new("git")
         .args(["lfs", "version"])
         .output()


### PR DESCRIPTION
Fixes #187

- Add Git LFS awareness to clone and pull commands
- After cloning repos (via libgit2), LFS repos get a sequential git lfs pull phase with visible progress output so users can see large file downloads
- After pulling repos, git lfs pull runs automatically for repos that use LFS
- Both commands now show an LFS column in the summary table and surface LFS errors in the error summary
