### PR TITLE
Speed up lfs functions in `status` and `pull`

### DIFF
--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -124,6 +124,7 @@ impl Status {
             LfsPullStatus::Failed(_) => cell!(Frr -> "Failed"),
             LfsPullStatus::NotNeeded => cell!(r -> "-"),
             LfsPullStatus::LfsNotInstalled => cell!(Fyr -> "No LFS installed"),
+            LfsPullStatus::IndexRefreshed => cell!(Fgr -> "Index Fixed"),
         }
     }
 

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -213,7 +213,10 @@ fn pull(dir: &PathBuf, user: &User, stash: bool, merge: bool) -> Status {
 
     let status = pull().map_err(Arc::new);
 
-    let lfs_status = if status.is_ok() {
+    let lfs_status = if matches!(
+        &status,
+        Ok(PullStatus::FastForward) | Ok(PullStatus::Normal)
+    ) {
         lfs::lfs_pull(dir)
     } else {
         LfsPullStatus::NotNeeded

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -219,6 +219,26 @@ fn pull(dir: &PathBuf, user: &User, stash: bool, merge: bool) -> Status {
     ) {
         lfs::lfs_pull(dir)
     } else {
+        // Even when we didn't pull, refresh the LFS index for dirty LFS repos
+        // to fix stale stat cache entries that cause false "modified" reports.
+        if matches!(repo_status, RepoStatus::Dirty) && lfs::repo_uses_lfs(dir) {
+            lfs::refresh_lfs_index(dir);
+            // Re-check status — the refresh may have fixed false modifications
+            if let Ok(git_repo) = git::open(dir) {
+                if let Ok(new_status) = git::status(&git_repo, false) {
+                    if !new_status.is_dirty() {
+                        repo_status = RepoStatus::Clean;
+                        return Status {
+                            repo: dir_name,
+                            status,
+                            repo_status,
+                            stash_status,
+                            lfs_status: LfsPullStatus::IndexRefreshed,
+                        };
+                    }
+                }
+            }
+        }
         LfsPullStatus::NotNeeded
     };
 
@@ -271,6 +291,7 @@ impl Status {
             LfsPullStatus::Failed(_) => cell!(Frr -> "Failed"),
             LfsPullStatus::NotNeeded => cell!(r -> "-"),
             LfsPullStatus::LfsNotInstalled => cell!(Fyr -> "No LFS installed"),
+            LfsPullStatus::IndexRefreshed => cell!(Fgr -> "Index Fixed"),
         }
     }
 

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -224,9 +224,9 @@ fn pull(dir: &PathBuf, user: &User, stash: bool, merge: bool) -> Status {
         if matches!(repo_status, RepoStatus::Dirty) && lfs::repo_uses_lfs(dir) {
             lfs::refresh_lfs_index(dir);
             // Re-check status — the refresh may have fixed false modifications
-            if let Ok(git_repo) = git::open(dir) {
-                if let Ok(new_status) = git::status(&git_repo, false) {
-                    if !new_status.is_dirty() {
+            if let Ok(git_repo) = git::open(dir)
+                && let Ok(new_status) = git::status(&git_repo, false)
+                    && !new_status.is_dirty() {
                         repo_status = RepoStatus::Clean;
                         return Status {
                             repo: dir_name,
@@ -236,8 +236,6 @@ fn pull(dir: &PathBuf, user: &User, stash: bool, merge: bool) -> Status {
                             lfs_status: LfsPullStatus::IndexRefreshed,
                         };
                     }
-                }
-            }
         }
         LfsPullStatus::NotNeeded
     };

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -226,16 +226,17 @@ fn pull(dir: &PathBuf, user: &User, stash: bool, merge: bool) -> Status {
             // Re-check status — the refresh may have fixed false modifications
             if let Ok(git_repo) = git::open(dir)
                 && let Ok(new_status) = git::status(&git_repo, false)
-                    && !new_status.is_dirty() {
-                        repo_status = RepoStatus::Clean;
-                        return Status {
-                            repo: dir_name,
-                            status,
-                            repo_status,
-                            stash_status,
-                            lfs_status: LfsPullStatus::IndexRefreshed,
-                        };
-                    }
+                && !new_status.is_dirty()
+            {
+                repo_status = RepoStatus::Clean;
+                return Status {
+                    repo: dir_name,
+                    status,
+                    repo_status,
+                    stash_status,
+                    lfs_status: LfsPullStatus::IndexRefreshed,
+                };
+            }
         }
         LfsPullStatus::NotNeeded
     };

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -68,7 +68,9 @@ impl StatusArgs {
 
         let sub_dirs = common::read_dirs_for_owner(owner, &root, self.regex.as_ref())?;
 
-        let statuses: Vec<_> = sub_dirs.iter().map(status).collect();
+        let statuses = common::process_with_progress("Status", &sub_dirs, status, |result| {
+            result.name.clone()
+        });
 
         let filtered_statuses: Vec<_> = statuses
             .iter()

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -39,6 +39,9 @@ pub struct StatusArgs {
     #[arg(long, short)]
     /// Fetch from remotes before showing status
     pub fetch: bool,
+    #[arg(long, short)]
+    /// Show detailed LFS file download status
+    pub lfs: bool,
 }
 
 impl StatusArgs {
@@ -68,9 +71,13 @@ impl StatusArgs {
 
         let sub_dirs = common::read_dirs_for_owner(owner, &root, self.regex.as_ref())?;
 
-        let statuses = common::process_with_progress("Status", &sub_dirs, status, |result| {
-            result.name.clone()
-        });
+        let detailed_lfs = self.lfs;
+        let statuses = common::process_with_progress(
+            "Status",
+            &sub_dirs,
+            |dir| status(dir, detailed_lfs),
+            |result| result.name.clone(),
+        );
 
         let filtered_statuses: Vec<_> = statuses
             .iter()
@@ -144,7 +151,7 @@ impl StatusArgs {
     }
 }
 
-fn status(dir: &PathBuf) -> StatusResult {
+fn status(dir: &PathBuf, detailed_lfs: bool) -> StatusResult {
     let name = dir_name(dir).unwrap_or_else(|_| "Unknown".to_string());
 
     let result = (|| -> Result<RepoStatus> {
@@ -155,7 +162,7 @@ fn status(dir: &PathBuf) -> StatusResult {
         let branch = git::head_shorthand(&git_repo)?;
 
         let uses_lfs = lfs::repo_uses_lfs(dir);
-        let lfs_files = if uses_lfs && system_health::is_git_lfs_installed() {
+        let lfs_files = if detailed_lfs && uses_lfs && system_health::is_git_lfs_installed() {
             lfs::lfs_file_status(dir)
         } else {
             None
@@ -387,7 +394,7 @@ impl RepoStatus {
                 format!("{}/{}", adjusted_downloaded, lfs_files.total)
             }
         } else {
-            "-".to_string()
+            "YES".to_string()
         };
 
         StatusRow::RepoSummarize {

--- a/src/git/lfs.rs
+++ b/src/git/lfs.rs
@@ -9,6 +9,7 @@ pub enum LfsPullStatus {
     Failed(String),
     NotNeeded,
     LfsNotInstalled,
+    IndexRefreshed,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]
@@ -101,7 +102,7 @@ pub fn lfs_pull_verbose(repo_path: &Path) -> LfsPullStatus {
 /// even though their content matches the index. Running `git update-index` for each
 /// LFS file re-reads the file, applies the clean filter, and writes the correct stat
 /// into the cache so subsequent `git status` calls report a clean working tree.
-fn refresh_lfs_index(repo_path: &Path) {
+pub fn refresh_lfs_index(repo_path: &Path) {
     let ls = match Command::new("git")
         .args(["lfs", "ls-files", "-n"])
         .current_dir(repo_path)


### PR DESCRIPTION
Fixes #226 

Adds the following changes
- Parallelizes the `status` command to make it faster in general, and especially when dealing with lfs
- Adds `--lfs` option to `status`. Without it, it is still reported whether each repo uses lfs. With the `--lfs` option, it runs the more expensive lfs command that can output how many files are missing (eg 6/7 if 6 out of 7 lfs files have been downloaded), or displays "YES" if all files are accounted for.
- Only run `git lfs pull` if `git pull` had changes. This was previously being run for all lfs repos regardless of whether they changed.
- When running pull, if a repo is "dirty" it may be because the lfs index is messed up and needs fixing (what caused #222). In these cases, try updating the lfs index and report if successful. This was previously running as a part of pull (above), which slowed things down.

This should fix slowness while maintaining the lfs fix (#222) without having to introduce new commands and terminology the user must know about.