### PR TITLE
Prompt for GitHub token with hidden input in gut init

### DIFF
--- a/src/commands/init_config.rs
+++ b/src/commands/init_config.rs
@@ -3,6 +3,7 @@ use crate::github;
 use crate::system_health;
 use crate::user::User;
 use clap::Parser;
+use dialoguer::Password;
 use std::path::PathBuf;
 
 fn validate_root(root: &str) -> Result<PathBuf, String> {
@@ -40,9 +41,6 @@ pub struct InitArgs {
     ///
     /// All repositories will be cloned under this directory
     pub root: PathBuf,
-    #[arg(short, long)]
-    /// Github token. Gut needs github token to access your github data
-    pub token: String,
     /// Default owner (can be a GitHub organisation or user account)
     #[arg(short, long, alias = "organisation")]
     pub owner: Option<String>,
@@ -51,11 +49,20 @@ pub struct InitArgs {
     pub use_https: bool,
 }
 
+fn prompt_token() -> anyhow::Result<String> {
+    Password::new()
+        .with_prompt("GitHub token")
+        .allow_empty_password(false)
+        .interact()
+        .map_err(|e| anyhow::anyhow!("Failed to read GitHub token: {e}"))
+}
+
 impl InitArgs {
     pub fn save_config(&self) -> anyhow::Result<()> {
         let warnings = system_health::check_git_config();
 
-        let user = match User::new(self.token.clone()) {
+        let token = prompt_token()?;
+        let user = match User::new(token) {
             Ok(user) => user,
             Err(e) => match e.downcast_ref::<github::Unauthorized>() {
                 Some(_) => anyhow::bail!(

--- a/src/commands/repo_health/checks.rs
+++ b/src/commands/repo_health/checks.rs
@@ -255,7 +255,7 @@ fn check_repo_for_large_files_and_long_paths(
     })?;
 
     // Sort by size (largest first) and convert to Issues
-    large_files.sort_by(|a, b| b.1.cmp(&a.1));
+    large_files.sort_by_key(|b| std::cmp::Reverse(b.1));
     for (file_path, size_bytes) in large_files {
         issues.push(Issue {
             repo: repo_name.to_owned(),
@@ -266,7 +266,7 @@ fn check_repo_for_large_files_and_long_paths(
         });
     }
 
-    large_ignored_files.sort_by(|a, b| b.1.cmp(&a.1));
+    large_ignored_files.sort_by_key(|b| std::cmp::Reverse(b.1));
     for (file_path, size_bytes) in large_ignored_files {
         issues.push(Issue {
             repo: repo_name.to_owned(),
@@ -278,7 +278,7 @@ fn check_repo_for_large_files_and_long_paths(
     }
 
     // Sort long paths by path length (longest first)
-    long_paths.sort_by(|a, b| b.1.cmp(&a.1));
+    long_paths.sort_by_key(|b| std::cmp::Reverse(b.1));
     for (file_path, path_bytes, filename_bytes) in long_paths {
         issues.push(Issue {
             repo: repo_name.to_owned(),


### PR DESCRIPTION
## Summary
- remove `--token` CLI argument from `gut init`
- prompt for GitHub token interactively using hidden input (`dialoguer::Password`)
- keep token validation flow unchanged after input

## Why
Passing secrets on the command line can leak into shell history or process listings. Hidden prompt input is safer and matches `sudo`/`mysql -p` style workflows.

## Notes
- This PR is intentionally separate from keyring storage changes.
- Existing behavior for invalid token errors is unchanged.
